### PR TITLE
fix: migrate hardcoded colors to theme for dark mode

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
@@ -39,16 +37,6 @@ class MainActivity : ComponentActivity() {
                 .collectAsStateWithLifecycle(initialValue = UserPreferencesRepository.THEME_SYSTEM)
             val fontScale by userPreferencesRepository.fontScale
                 .collectAsStateWithLifecycle(initialValue = 1.0f)
-
-            LaunchedEffect(themeMode) {
-                AppCompatDelegate.setDefaultNightMode(
-                    when (themeMode) {
-                        UserPreferencesRepository.THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-                        UserPreferencesRepository.THEME_DARK -> AppCompatDelegate.MODE_NIGHT_YES
-                        else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                    }
-                )
-            }
 
             CompositionLocalProvider(
                 LocalDensity provides Density(

--- a/app/src/main/java/cn/gdeiassistant/ui/grade/GradeDetailScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/grade/GradeDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -186,13 +187,18 @@ private fun DetailRow(label: String, value: String) {
     }
 }
 
+@Composable
 private fun detailBadgeStyle(raw: String): Pair<Color, Color> {
     val score = raw.toDoubleOrNull()
-        ?: return Color(0xFFF1F2F6) to Color(0xFF30394A)
+        ?: return MaterialTheme.colorScheme.surfaceContainerHighest to MaterialTheme.colorScheme.onSurface
+    val green = Color(0xFF0E7A63)
+    val blue = Color(0xFF1764F6)
+    val amber = Color(0xFFB7791F)
+    val red = Color(0xFFC2412D)
     return when {
-        score >= 90 -> Color(0xFFE8FAF3) to Color(0xFF0E7A63)
-        score >= 80 -> Color(0xFFEFF6FF) to Color(0xFF1764F6)
-        score >= 60 -> Color(0xFFFFF4DE) to Color(0xFFB7791F)
-        else -> Color(0xFFFFECE8) to Color(0xFFC2412D)
+        score >= 90 -> green.copy(alpha = 0.12f).compositeOver(MaterialTheme.colorScheme.surface) to green
+        score >= 80 -> blue.copy(alpha = 0.12f).compositeOver(MaterialTheme.colorScheme.surface) to blue
+        score >= 60 -> amber.copy(alpha = 0.12f).compositeOver(MaterialTheme.colorScheme.surface) to amber
+        else -> red.copy(alpha = 0.12f).compositeOver(MaterialTheme.colorScheme.surface) to red
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
@@ -61,16 +61,23 @@ import cn.gdeiassistant.ui.theme.AppShapes
 import cn.gdeiassistant.ui.util.asString
 import kotlinx.coroutines.flow.collectLatest
 
-private val LoginBackground = Brush.verticalGradient(
+@Composable
+private fun loginBackground(): Brush = Brush.verticalGradient(
     colors = listOf(
-        Color(0xFFF7F7FF),
-        Color(0xFFF1F3FF),
-        Color(0xFFEEF5FF)
+        MaterialTheme.colorScheme.surface,
+        MaterialTheme.colorScheme.surfaceContainerLow,
+        MaterialTheme.colorScheme.surfaceContainer
     )
 )
-private val LoginCardBorder = Color(0x1F3A235A)
-private val LoginMockTint = Color(0xFF5E35B1)
-private val LoginMockContainer = Color(0xFFF1EBFF)
+
+@Composable
+private fun loginCardBorder(): Color = MaterialTheme.colorScheme.outlineVariant
+
+@Composable
+private fun loginMockTint(): Color = MaterialTheme.colorScheme.tertiary
+
+@Composable
+private fun loginMockContainer(): Color = MaterialTheme.colorScheme.tertiaryContainer
 
 @Composable
 fun LoginScreen(navController: NavHostController) {
@@ -112,7 +119,7 @@ private fun LoginContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(LoginBackground)
+            .background(loginBackground())
             .statusBarsPadding()
             .navigationBarsPadding()
             .imePadding()
@@ -158,7 +165,7 @@ private fun LoginHeader() {
                 .background(
                     Brush.linearGradient(
                         colors = listOf(
-                            LoginMockTint.copy(alpha = 0.16f),
+                            loginMockTint().copy(alpha = 0.16f),
                             MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f)
                         )
                     )
@@ -212,7 +219,7 @@ private fun LoginFormCard(
             .animateContentSize(),
         shape = AppShapes.card,
         color = MaterialTheme.colorScheme.surface,
-        border = androidx.compose.foundation.BorderStroke(1.dp, LoginCardBorder)
+        border = androidx.compose.foundation.BorderStroke(1.dp, loginCardBorder())
     ) {
         Column(
             modifier = Modifier
@@ -320,7 +327,7 @@ private fun LoginMockCard(
             .animateContentSize(),
         shape = AppShapes.card,
         color = MaterialTheme.colorScheme.surface,
-        border = androidx.compose.foundation.BorderStroke(1.dp, LoginCardBorder)
+        border = androidx.compose.foundation.BorderStroke(1.dp, loginCardBorder())
     ) {
         Column(
             modifier = Modifier
@@ -336,13 +343,13 @@ private fun LoginMockCard(
                     modifier = Modifier
                         .size(42.dp)
                         .clip(CircleShape)
-                        .background(LoginMockContainer),
+                        .background(loginMockContainer()),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.DataObject,
                         contentDescription = null,
-                        tint = LoginMockTint
+                        tint = loginMockTint()
                     )
                 }
                 Spacer(modifier = Modifier.width(14.dp))
@@ -377,14 +384,14 @@ private fun LoginMockCard(
             ) {
                 Surface(
                     shape = AppShapes.button,
-                    color = LoginMockContainer,
-                    border = androidx.compose.foundation.BorderStroke(1.dp, LoginMockTint.copy(alpha = 0.14f))
+                    color = loginMockContainer(),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, loginMockTint().copy(alpha = 0.14f))
                 ) {
                     Text(
                         text = stringResource(R.string.login_mock_account_hint),
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = LoginMockTint
+                        color = loginMockTint()
                     )
                 }
             }

--- a/app/src/main/java/cn/gdeiassistant/ui/screen/WebScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/screen/WebScreen.kt
@@ -72,14 +72,14 @@ import cn.gdeiassistant.ui.components.BadgePill
 import cn.gdeiassistant.ui.components.HeroCard
 import cn.gdeiassistant.ui.components.MetricChip
 
-private val WebBackground = Color(0xFFF2F7FF)
-private val WebBackgroundElevated = Color(0xFFE7F1FF)
-private val WebHeroStart = Color(0xFF1764F6)
-private val WebHeroEnd = Color(0xFF1CC69A)
-private val WebSurface = Color(0xFFFFFFFF)
-private val WebBorder = Color(0xFFD8E7FC)
-private val WebErrorSurface = Color(0xFFFFF4EE)
-private val WebErrorBorder = Color(0xFFF0C8B8)
+@Composable private fun webBackground(): Color = MaterialTheme.colorScheme.surface
+@Composable private fun webBackgroundElevated(): Color = MaterialTheme.colorScheme.surfaceContainerLow
+@Composable private fun webHeroStart(): Color = MaterialTheme.colorScheme.primary
+@Composable private fun webHeroEnd(): Color = MaterialTheme.colorScheme.tertiary
+@Composable private fun webSurface(): Color = MaterialTheme.colorScheme.surface
+@Composable private fun webBorder(): Color = MaterialTheme.colorScheme.outlineVariant
+@Composable private fun webErrorSurface(): Color = MaterialTheme.colorScheme.errorContainer
+@Composable private fun webErrorBorder(): Color = MaterialTheme.colorScheme.error.copy(alpha = 0.38f)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -195,10 +195,10 @@ fun WebScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
-            pageBackground = WebBackground,
-            pageBackgroundElevated = WebBackgroundElevated,
-            primaryGlow = WebHeroStart.copy(alpha = 0.14f),
-            secondaryGlow = WebHeroEnd.copy(alpha = 0.14f)
+            pageBackground = webBackground(),
+            pageBackgroundElevated = webBackgroundElevated(),
+            primaryGlow = webHeroStart().copy(alpha = 0.14f),
+            secondaryGlow = webHeroEnd().copy(alpha = 0.14f)
         ) {
             Column(
                 modifier = Modifier
@@ -224,7 +224,7 @@ fun WebScreen(
                         subtitle = if (isLoading) "${progress.coerceIn(0, 100)}%" else null,
                         icon = Icons.Rounded.Refresh,
                         onClick = reloadInApp,
-                        tint = WebHeroStart,
+                        tint = webHeroStart(),
                         emphasized = isLoading,
                         modifier = Modifier.weight(1f)
                     )
@@ -233,7 +233,7 @@ fun WebScreen(
                         subtitle = if (!isValidUrl) stringResource(R.string.web_invalid_url) else null,
                         icon = Icons.Rounded.OpenInBrowser,
                         onClick = openInBrowser,
-                        tint = WebHeroEnd,
+                        tint = webHeroEnd(),
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -249,7 +249,7 @@ fun WebScreen(
                                 icon = Icons.Rounded.Report,
                                 title = stringResource(R.string.web_empty_hint),
                                 message = stringResource(R.string.web_invalid_url),
-                                tint = WebHeroStart
+                                tint = webHeroStart()
                             )
                         }
 
@@ -260,7 +260,7 @@ fun WebScreen(
                                 message = stringResource(R.string.web_untrusted_message),
                                 primaryActionLabel = stringResource(R.string.web_open_browser),
                                 onPrimaryAction = openInBrowser,
-                                tint = WebHeroStart
+                                tint = webHeroStart()
                             )
                         }
 
@@ -273,8 +273,8 @@ fun WebScreen(
                                 onPrimaryAction = reloadInApp,
                                 secondaryActionLabel = stringResource(R.string.web_open_browser),
                                 onSecondaryAction = openInBrowser,
-                                surface = WebErrorSurface,
-                                border = WebErrorBorder,
+                                surface = webErrorSurface(),
+                                border = webErrorBorder(),
                                 tint = MaterialTheme.colorScheme.error
                             )
                         }
@@ -426,8 +426,8 @@ private fun WebHeroCard(
 
     HeroCard(
         modifier = Modifier.fillMaxWidth(),
-        start = WebHeroStart,
-        end = WebHeroEnd
+        start = webHeroStart(),
+        end = webHeroEnd()
     ) {
         Row(
             modifier = Modifier.horizontalScroll(chipScrollState),
@@ -492,17 +492,17 @@ private fun WebCanvasCard(
     Card(
         modifier = Modifier.fillMaxSize(),
         shape = AppShapes.card,
-        colors = CardDefaults.cardColors(containerColor = WebSurface),
+        colors = CardDefaults.cardColors(containerColor = webSurface()),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        border = BorderStroke(1.dp, WebBorder)
+        border = BorderStroke(1.dp, webBorder())
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             if (isLoading) {
                 LinearProgressIndicator(
                     progress = { progress.coerceIn(0, 100) / 100f },
                     modifier = Modifier.fillMaxWidth(),
-                    color = WebHeroStart,
-                    trackColor = WebHeroStart.copy(alpha = 0.12f)
+                    color = webHeroStart(),
+                    trackColor = webHeroStart().copy(alpha = 0.12f)
                 )
             }
             Box(
@@ -524,9 +524,9 @@ private fun WebStateCard(
     onPrimaryAction: (() -> Unit)? = null,
     secondaryActionLabel: String? = null,
     onSecondaryAction: (() -> Unit)? = null,
-    surface: Color = WebSurface,
-    border: Color = WebBorder,
-    tint: Color = WebHeroStart
+    surface: Color = webSurface(),
+    border: Color = webBorder(),
+    tint: Color = webHeroStart()
 ) {
     Card(
         modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## Summary
- LoginScreen: purple palette → MaterialTheme.colorScheme (tertiary/tertiaryContainer)
- WebScreen: blue palette → theme-aware composable functions
- GradeDetailScreen: score badges use compositeOver() for dark mode
- Remove unused AppCompatDelegate (pure Compose app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)