### PR TITLE
Wire up locale, device binding, library pagination, and fix build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ android {
 
 dependencies {
     // Core
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
 

--- a/app/src/main/java/cn/gdeiassistant/GdeiAssistantApplication.kt
+++ b/app/src/main/java/cn/gdeiassistant/GdeiAssistantApplication.kt
@@ -1,11 +1,13 @@
 package cn.gdeiassistant
 
 import android.app.Application
+import cn.gdeiassistant.R
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.graphics.Color
 import cn.gdeiassistant.data.SettingsRepository
+import cn.gdeiassistant.network.AppContextProvider
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +23,7 @@ class GdeiAssistantApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        AppContextProvider.init(this)
         applicationScope.launch {
             settingsRepository.initializeSyncCache()
         }
@@ -29,7 +32,7 @@ class GdeiAssistantApplication : Application() {
 
     fun createServiceForegroundNotificationChannel() {
         val channelId = "service"
-        val channelName = "系统公告"
+        val channelName = getString(R.string.notification_channel_service)
         val channel = NotificationChannel(
             channelId,
             channelName,

--- a/app/src/main/java/cn/gdeiassistant/data/ChargeRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/ChargeRepository.kt
@@ -32,7 +32,7 @@ class ChargeRepository @Inject constructor(
             val serverPublicKey = safeApiCall { chargeApi.getServerPublicKey() }
                 .getOrElse { return@withContext Result.failure(it) }
                 ?.takeIf { it.isNotBlank() }
-                ?: return@withContext Result.failure(IllegalStateException("未获取到服务端公钥"))
+                ?: return@withContext Result.failure(IllegalStateException(context.getString(R.string.charge_error_no_server_public_key)))
 
             val requestValidateToken = context.getString(R.string.request_validate_token)
             val nonce = UUID.randomUUID().toString().replace("-", "")
@@ -74,21 +74,21 @@ class ChargeRepository @Inject constructor(
                     clientRSASignature = clientSignature
                 )
             }.getOrElse { return@withContext Result.failure(it) }
-                ?: return@withContext Result.failure(IllegalStateException("服务端未返回支付信息"))
+                ?: return@withContext Result.failure(IllegalStateException(context.getString(R.string.charge_error_no_payment_info)))
 
             val encryptedData = encryptedResponse.data
                 ?.takeIf { it.isNotBlank() }
-                ?: return@withContext Result.failure(IllegalStateException("支付信息为空"))
+                ?: return@withContext Result.failure(IllegalStateException(context.getString(R.string.charge_error_empty_payment_data)))
             val encryptedSignature = encryptedResponse.signature
                 ?.takeIf { it.isNotBlank() }
-                ?: return@withContext Result.failure(IllegalStateException("支付签名为空"))
+                ?: return@withContext Result.failure(IllegalStateException(context.getString(R.string.charge_error_empty_payment_signature)))
 
             val chargeJson = String(
                 ChargeCrypto.decryptWithAes(aesKey, Base64.decode(encryptedData, Base64.NO_WRAP)),
                 Charsets.UTF_8
             )
             val charge = Gson().fromJson(chargeJson, Charge::class.java)
-                ?: return@withContext Result.failure(IllegalStateException("支付信息解析失败"))
+                ?: return@withContext Result.failure(IllegalStateException(context.getString(R.string.charge_error_parse_failed)))
             val expectedSignature = ChargeCrypto.sha1Hex(Gson().toJson(charge))
             val actualSignature = String(
                 ChargeCrypto.decryptWithPublicKey(
@@ -110,7 +110,7 @@ class ChargeRepository @Inject constructor(
 
     private fun requireToken(): String {
         val token = sessionManager.currentToken()
-        if (token.isNullOrBlank()) throw IllegalStateException("请先登录")
+        if (token.isNullOrBlank()) throw IllegalStateException(context.getString(R.string.charge_error_login_required))
         return token
     }
 

--- a/app/src/main/java/cn/gdeiassistant/model/InformationModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/model/InformationModels.kt
@@ -1,6 +1,9 @@
 package cn.gdeiassistant.model
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.res.stringResource
+import cn.gdeiassistant.R
 import java.io.Serializable
 
 @Immutable
@@ -70,12 +73,13 @@ data class Festival(
     val description: List<String>?
 ) : Serializable
 
+@Composable
 fun newsSourceLabel(type: Int): String {
     return when (type) {
-        1 -> "学校要闻"
-        2 -> "院部通知"
-        3 -> "通知公告"
-        4 -> "学术动态"
-        else -> "新闻"
+        1 -> stringResource(R.string.news_source_important)
+        2 -> stringResource(R.string.news_source_department)
+        3 -> stringResource(R.string.news_source_announcement)
+        4 -> stringResource(R.string.news_source_academic)
+        else -> stringResource(R.string.news_source_default)
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/network/AppContextProvider.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/AppContextProvider.kt
@@ -1,0 +1,28 @@
+package cn.gdeiassistant.network
+
+import android.annotation.SuppressLint
+import android.content.Context
+
+/**
+ * Provides Application-level Context for the network layer (interceptors, safe-api-call helpers)
+ * where Hilt injection of Context is impractical.
+ *
+ * Must be initialised in [cn.gdeiassistant.GdeiAssistantApplication.onCreate].
+ */
+@SuppressLint("StaticFieldLeak") // Holds Application context only – no leak risk.
+object AppContextProvider {
+
+    private var _context: Context? = null
+
+    val context: Context
+        get() = _context ?: throw IllegalStateException(
+            "AppContextProvider has not been initialised. Call init() in Application.onCreate()."
+        )
+
+    /** Returns the context if already initialised, or null otherwise. */
+    val contextOrNull: Context? get() = _context
+
+    fun init(appContext: Context) {
+        _context = appContext.applicationContext
+    }
+}

--- a/app/src/main/java/cn/gdeiassistant/network/AppException.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/AppException.kt
@@ -1,5 +1,7 @@
 package cn.gdeiassistant.network
 
+import cn.gdeiassistant.R
+
 /**
  * 携带后端返回的 message 与 HTTP 状态码的统一异常。
  * 用于拦截器、SafeApiCall 及 UI 层展示后端原始错误文案。
@@ -7,4 +9,8 @@ package cn.gdeiassistant.network
 class AppException(
     message: String?,
     val code: Int = -1
-) : RuntimeException(message ?: "请求失败")
+) : RuntimeException(
+    message
+        ?: AppContextProvider.contextOrNull?.getString(R.string.network_error_generic)
+        ?: "Request failed"
+)

--- a/app/src/main/java/cn/gdeiassistant/network/NetworkConstants.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/NetworkConstants.kt
@@ -1,5 +1,7 @@
 package cn.gdeiassistant.network
 
+import cn.gdeiassistant.R
+
 /**
  * 网络层常量：HTTP 状态码与超时时间，避免魔法数字。
  */
@@ -14,11 +16,20 @@ object NetworkConstants {
     /** 读写超时（秒） */
     const val READ_WRITE_TIMEOUT_SECONDS = 20
 
-    /** 401 时兜底提示（网络层无 Context，与 strings.login_expired_toast 保持一致） */
-    const val MESSAGE_LOGIN_EXPIRED = "登录已过期，请重新登录"
+    /* ---- localised error messages resolved via AppContextProvider ---- */
 
-    const val MESSAGE_FORBIDDEN = "权限不足"
-    const val MESSAGE_NETWORK_ERROR = "网络异常，请检查网络连接"
-    const val MESSAGE_REQUEST_FAILED = "请求失败"
-    const val MESSAGE_SERVER_ERROR = "服务器错误: %d"
+    fun messageLoginExpired(): String =
+        AppContextProvider.context.getString(R.string.login_expired_toast)
+
+    fun messageForbidden(): String =
+        AppContextProvider.context.getString(R.string.network_error_forbidden)
+
+    fun messageNetworkError(): String =
+        AppContextProvider.context.getString(R.string.network_error_generic)
+
+    fun messageRequestFailed(): String =
+        AppContextProvider.context.getString(R.string.network_error_request_failed)
+
+    fun messageServerError(code: Int): String =
+        AppContextProvider.context.getString(R.string.network_error_server, code)
 }

--- a/app/src/main/java/cn/gdeiassistant/network/RetrofitClient.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/RetrofitClient.kt
@@ -42,14 +42,14 @@ class ResponseInterceptor @Inject constructor(
             val message = parseMessageFromBody(bodyStr)
             sessionManager.clearTokens()
             GlobalEventManager.emit(GlobalEvent.Unauthorized)
-            throw AppException(message ?: NetworkConstants.MESSAGE_LOGIN_EXPIRED, NetworkConstants.HTTP_UNAUTHORIZED)
+            throw AppException(message ?: NetworkConstants.messageLoginExpired(), NetworkConstants.HTTP_UNAUTHORIZED)
         }
 
         if (!response.isSuccessful) {
             val bodyStr = response.peekBody(64 * 1024).string()
             val message = parseMessageFromBody(bodyStr)
-            GlobalEventManager.emit(GlobalEvent.ShowToast(message ?: "请求失败"))
-            throw AppException(message ?: "请求失败", response.code)
+            GlobalEventManager.emit(GlobalEvent.ShowToast(message ?: NetworkConstants.messageRequestFailed()))
+            throw AppException(message ?: NetworkConstants.messageRequestFailed(), response.code)
         }
 
         return response

--- a/app/src/main/java/cn/gdeiassistant/network/RetrofitClient.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/RetrofitClient.kt
@@ -6,6 +6,7 @@ import cn.gdeiassistant.event.GlobalEventManager
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
+import android.provider.Settings
 import okhttp3.Interceptor
 import javax.inject.Inject
 
@@ -19,6 +20,13 @@ class AuthInterceptor @Inject constructor(
         val request = chain.request().newBuilder().apply {
             sessionManager.currentToken()?.takeIf { it.isNotBlank() }?.let { token ->
                 addHeader("Authorization", "Bearer $token")
+            }
+            val deviceId = Settings.Secure.getString(
+                AppContextProvider.context.contentResolver,
+                Settings.Secure.ANDROID_ID
+            )
+            if (!deviceId.isNullOrBlank()) {
+                addHeader("X-Device-ID", deviceId)
             }
         }.build()
         return chain.proceed(request)

--- a/app/src/main/java/cn/gdeiassistant/network/SafeApiCall.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/SafeApiCall.kt
@@ -50,7 +50,7 @@ private suspend inline fun <Response, ResultType> safeResultCall(
         } else {
             Result.failure(
                 AppException(
-                    errorMessage(response) ?: NetworkConstants.MESSAGE_REQUEST_FAILED,
+                    errorMessage(response) ?: NetworkConstants.messageRequestFailed(),
                     errorCode(response) ?: -1
                 )
             )
@@ -60,13 +60,13 @@ private suspend inline fun <Response, ResultType> safeResultCall(
     } catch (e: HttpException) {
         val message = e.response()?.errorBody()?.string()?.let { parseMessageFromErrorBody(it) }
             ?: when (e.code()) {
-                NetworkConstants.HTTP_UNAUTHORIZED -> NetworkConstants.MESSAGE_LOGIN_EXPIRED
-                NetworkConstants.HTTP_FORBIDDEN -> NetworkConstants.MESSAGE_FORBIDDEN
-                else -> NetworkConstants.MESSAGE_SERVER_ERROR.format(e.code())
+                NetworkConstants.HTTP_UNAUTHORIZED -> NetworkConstants.messageLoginExpired()
+                NetworkConstants.HTTP_FORBIDDEN -> NetworkConstants.messageForbidden()
+                else -> NetworkConstants.messageServerError(e.code())
             }
         Result.failure(AppException(message, e.code()))
     } catch (e: IOException) {
-        Result.failure(AppException(NetworkConstants.MESSAGE_NETWORK_ERROR, -1))
+        Result.failure(AppException(NetworkConstants.messageNetworkError(), -1))
     } catch (e: Exception) {
         Result.failure(e)
     }

--- a/app/src/main/java/cn/gdeiassistant/network/api/ChargeApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/ChargeApi.kt
@@ -20,7 +20,7 @@ interface ChargeApi {
     @POST("api/card/charge")
     suspend fun submitCharge(
         @Header("Version-Code") versionCode: String,
-        @Header("Client-Type") clientType: String,
+        @Header("X-Client-Type") clientType: String,
         @Header("User-Agent") userAgent: String,
         @Field("amount") amount: String,
         @Field("token") token: String,

--- a/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
@@ -4,17 +4,24 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import cn.gdeiassistant.data.SessionManager
+import cn.gdeiassistant.data.SettingsRepository
 import cn.gdeiassistant.data.UserPreferencesRepository
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import cn.gdeiassistant.ui.theme.GdeiAssistantTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -26,11 +33,27 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var userPreferencesRepository: UserPreferencesRepository
 
+    @Inject
+    lateinit var settingsRepository: SettingsRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         actionBar?.hide()
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                settingsRepository.locale.collect { locale ->
+                    val currentAppLocales = AppCompatDelegate.getApplicationLocales()
+                    val newLocales = LocaleListCompat.forLanguageTags(locale)
+                    if (currentAppLocales != newLocales) {
+                        AppCompatDelegate.setApplicationLocales(newLocales)
+                    }
+                }
+            }
+        }
+
         setContent {
             val hasActiveSession = remember { sessionManager.hasActiveSession() }
             val themeMode by userPreferencesRepository.themeMode

--- a/app/src/main/java/cn/gdeiassistant/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/library/LibraryScreen.kt
@@ -131,11 +131,14 @@ fun LibraryScreen(navController: NavHostController) {
         item {
             SearchSection(
                 keyword = state.searchKeyword,
+                currentPage = state.currentPage,
                 totalPages = state.totalPages,
                 isSearching = state.isSearching,
                 onKeywordChange = viewModel::updateSearchKeyword,
                 onSearch = viewModel::search,
-                onClear = viewModel::clearSearch
+                onClear = viewModel::clearSearch,
+                onPreviousPage = viewModel::goToPreviousPage,
+                onNextPage = viewModel::goToNextPage
             )
         }
         if (!state.searchError.isNullOrBlank()) {
@@ -233,11 +236,14 @@ private fun LibraryOverviewCard(
 @Composable
 private fun SearchSection(
     keyword: String,
+    currentPage: Int,
     totalPages: Int,
     isSearching: Boolean,
     onKeywordChange: (String) -> Unit,
     onSearch: () -> Unit,
-    onClear: () -> Unit
+    onClear: () -> Unit,
+    onPreviousPage: () -> Unit,
+    onNextPage: () -> Unit
 ) {
     SectionCard(modifier = Modifier.fillMaxWidth()) {
         Text(
@@ -282,6 +288,30 @@ private fun SearchSection(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(
+                    onClick = onPreviousPage,
+                    enabled = currentPage > 1 && !isSearching
+                ) {
+                    Text(text = stringResource(R.string.library_page_previous))
+                }
+                Text(
+                    text = stringResource(R.string.library_page_indicator, currentPage, totalPages),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 12.dp)
+                )
+                TextButton(
+                    onClick = onNextPage,
+                    enabled = currentPage < totalPages && !isSearching
+                ) {
+                    Text(text = stringResource(R.string.library_page_next))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/library/LibraryViewModel.kt
@@ -23,6 +23,7 @@ import javax.inject.Inject
 
 data class LibraryUiState(
     val searchKeyword: String = "",
+    val currentPage: Int = 1,
     val searchResults: List<CollectionSearchItem> = emptyList(),
     val borrowPassword: String = "",
     val borrowedItems: List<CollectionBorrowItem> = emptyList(),
@@ -79,7 +80,7 @@ class LibraryViewModel @Inject constructor(
                 null
             }
             val searchDeferred = if (currentState.searchKeyword.isNotBlank()) {
-                async { repository.searchCollections(keyword = currentState.searchKeyword, page = 1) }
+                async { repository.searchCollections(keyword = currentState.searchKeyword, page = currentState.currentPage) }
             } else {
                 null
             }
@@ -102,12 +103,34 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun search() {
+        _state.update { it.copy(currentPage = 1) }
+        searchPage(1)
+    }
+
+    fun goToPreviousPage() {
+        val current = _state.value.currentPage
+        if (current > 1) {
+            _state.update { it.copy(currentPage = current - 1) }
+            searchPage(current - 1)
+        }
+    }
+
+    fun goToNextPage() {
+        val current = _state.value.currentPage
+        if (current < _state.value.totalPages) {
+            _state.update { it.copy(currentPage = current + 1) }
+            searchPage(current + 1)
+        }
+    }
+
+    private fun searchPage(page: Int) {
         val keyword = _state.value.searchKeyword.trim()
         if (keyword.isBlank()) {
             _state.update {
                 it.copy(
                     searchResults = emptyList(),
                     totalPages = 0,
+                    currentPage = 1,
                     searchError = null
                 )
             }
@@ -115,12 +138,12 @@ class LibraryViewModel @Inject constructor(
         }
         viewModelScope.launch {
             _state.update { it.copy(isSearching = true, searchError = null) }
-            repository.searchCollections(keyword = keyword, page = 1)
-                .onSuccess { page ->
+            repository.searchCollections(keyword = keyword, page = page)
+                .onSuccess { result ->
                     _state.update {
                         it.copy(
-                            searchResults = page.items,
-                            totalPages = page.sumPage,
+                            searchResults = result.items,
+                            totalPages = result.sumPage,
                             isSearching = false,
                             searchError = null
                         )
@@ -136,6 +159,7 @@ class LibraryViewModel @Inject constructor(
         _state.update {
             it.copy(
                 searchKeyword = "",
+                currentPage = 1,
                 searchResults = emptyList(),
                 totalPages = 0,
                 searchError = null

--- a/app/src/main/java/cn/gdeiassistant/ui/news/NewsDetailViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/news/NewsDetailViewModel.kt
@@ -1,8 +1,10 @@
 package cn.gdeiassistant.ui.news
 
+import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cn.gdeiassistant.R
 import cn.gdeiassistant.data.NewsRepository
 import cn.gdeiassistant.model.SchoolNews
 import cn.gdeiassistant.ui.navigation.Routes
@@ -23,7 +25,8 @@ data class NewsDetailUiState(
 @HiltViewModel
 class NewsDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val newsRepository: NewsRepository
+    private val newsRepository: NewsRepository,
+    private val application: Application
 ) : ViewModel() {
 
     private val newsId: String = savedStateHandle.get<String>(Routes.NEWS_DETAIL_ID).orEmpty()
@@ -40,7 +43,7 @@ class NewsDetailViewModel @Inject constructor(
             _state.value = NewsDetailUiState(
                 isLoading = false,
                 detail = null,
-                error = "缺少新闻编号"
+                error = application.getString(R.string.news_error_missing_id)
             )
             return
         }

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
+import cn.gdeiassistant.R
 import cn.gdeiassistant.ui.components.LazyScreen
 import kotlinx.coroutines.launch
 
@@ -45,7 +47,7 @@ fun LanguagePickerScreen(navController: NavHostController) {
     val scope = rememberCoroutineScope()
 
     LazyScreen(
-        title = "语言 / Language",
+        title = stringResource(R.string.language_picker_title),
         onBack = navController::popBackStack
     ) {
         languageOptions.forEach { option ->

--- a/app/src/main/java/cn/gdeiassistant/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/screen/HomeScreen.kt
@@ -37,7 +37,6 @@ import cn.gdeiassistant.ui.theme.AppShapes
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 private val SectionStartTimes = mapOf(
     0 to "08:00", 1 to "10:00", 2 to "14:00",
@@ -66,8 +65,9 @@ fun HomeScreen(navController: NavController) {
     } else {
         stringResource(R.string.home_greeting_without_name, greeting)
     }
+    val datePattern = stringResource(R.string.home_date_format)
     val todayLabel = LocalDate.now()
-        .format(DateTimeFormatter.ofPattern("M月d日 EEEE", Locale.SIMPLIFIED_CHINESE))
+        .format(DateTimeFormatter.ofPattern(datePattern))
 
     LazyScreen(
         title = greetingText,

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1503,4 +1503,29 @@
     <string name="appearance_font_preview">Preview: GdeiAssistant Campus Helper</string>
     <string name="appearance_language_label">Language</string>
 
+    <!-- Locale-aware strings -->
+    <string name="home_date_format">EEEE, MMM d</string>
+    <string name="notification_channel_service">System Announcements</string>
+    <string name="language_picker_title">Language</string>
+    <string name="news_error_missing_id">Missing news ID</string>
+    <string name="news_source_important">University News</string>
+    <string name="news_source_department">Department Notices</string>
+    <string name="news_source_announcement">Announcements</string>
+    <string name="news_source_academic">Academic Activities</string>
+    <string name="news_source_default">News</string>
+
+    <!-- Charge error strings -->
+    <string name="charge_error_no_server_public_key">Failed to obtain server public key</string>
+    <string name="charge_error_no_payment_info">Server did not return payment info</string>
+    <string name="charge_error_empty_payment_data">Payment data is empty</string>
+    <string name="charge_error_empty_payment_signature">Payment signature is empty</string>
+    <string name="charge_error_parse_failed">Failed to parse payment info</string>
+    <string name="charge_error_login_required">Please log in first</string>
+
+    <!-- Network error messages -->
+    <string name="network_error_forbidden">Access denied</string>
+    <string name="network_error_generic">Network error. Please check your connection.</string>
+    <string name="network_error_request_failed">Request failed</string>
+    <string name="network_error_server">Server error: %d</string>
+
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1186,6 +1186,9 @@
     <string name="library_collection_result_title">Search Results</string>
     <string name="library_collection_result_subtitle">Showing %1$d results</string>
     <string name="library_collection_result_pages">%1$d pages of results</string>
+    <string name="library_page_previous">Previous</string>
+    <string name="library_page_next">Next</string>
+    <string name="library_page_indicator">Page %1$d / %2$d</string>
     <string name="library_collection_detail_title">Collection Details</string>
     <string name="library_collection_detail_badge">Collection Info</string>
     <string name="library_collection_detail_loading">Loading collection details…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1186,6 +1186,9 @@
     <string name="library_collection_result_title">検索結果</string>
     <string name="library_collection_result_subtitle">%1$d 件の結果を表示</string>
     <string name="library_collection_result_pages">全 %1$d ページ</string>
+    <string name="library_page_previous">前のページ</string>
+    <string name="library_page_next">次のページ</string>
+    <string name="library_page_indicator">%1$d / %2$d ページ</string>
     <string name="library_collection_detail_title">蔵書詳細</string>
     <string name="library_collection_detail_badge">蔵書情報</string>
     <string name="library_collection_detail_loading">蔵書詳細を読み込み中…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1502,4 +1502,29 @@
     <string name="appearance_font_preview">プレビュー：広東第二師範学院キャンパスアシスタント</string>
     <string name="appearance_language_label">言語</string>
 
+    <!-- Locale-aware strings -->
+    <string name="home_date_format">M月d日 EEEE</string>
+    <string name="notification_channel_service">システム通知</string>
+    <string name="language_picker_title">言語 / Language</string>
+    <string name="news_error_missing_id">ニュースIDがありません</string>
+    <string name="news_source_important">大学ニュース</string>
+    <string name="news_source_department">学部通知</string>
+    <string name="news_source_announcement">お知らせ</string>
+    <string name="news_source_academic">学術動態</string>
+    <string name="news_source_default">ニュース</string>
+
+    <!-- Charge error strings -->
+    <string name="charge_error_no_server_public_key">サーバー公開鍵を取得できませんでした</string>
+    <string name="charge_error_no_payment_info">サーバーから決済情報が返されませんでした</string>
+    <string name="charge_error_empty_payment_data">決済情報が空です</string>
+    <string name="charge_error_empty_payment_signature">決済署名が空です</string>
+    <string name="charge_error_parse_failed">決済情報の解析に失敗しました</string>
+    <string name="charge_error_login_required">先にログインしてください</string>
+
+    <!-- Network error messages -->
+    <string name="network_error_forbidden">権限がありません</string>
+    <string name="network_error_generic">ネットワークエラーです。接続を確認してください</string>
+    <string name="network_error_request_failed">リクエストに失敗しました</string>
+    <string name="network_error_server">サーバーエラー: %d</string>
+
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1186,6 +1186,9 @@
     <string name="library_collection_result_title">검색 결과</string>
     <string name="library_collection_result_subtitle">총 %1$d 건 표시</string>
     <string name="library_collection_result_pages">총 %1$d 페이지 결과</string>
+    <string name="library_page_previous">이전 페이지</string>
+    <string name="library_page_next">다음 페이지</string>
+    <string name="library_page_indicator">%1$d / %2$d 페이지</string>
     <string name="library_collection_detail_title">소장 상세</string>
     <string name="library_collection_detail_badge">소장 정보</string>
     <string name="library_collection_detail_loading">소장 상세 로딩 중…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1502,4 +1502,29 @@
     <string name="appearance_font_preview">미리보기: 광동제2사범학원 캠퍼스 도우미</string>
     <string name="appearance_language_label">언어</string>
 
+    <!-- Locale-aware strings -->
+    <string name="home_date_format">M월 d일 EEEE</string>
+    <string name="notification_channel_service">시스템 공지</string>
+    <string name="language_picker_title">언어 / Language</string>
+    <string name="news_error_missing_id">뉴스 ID가 없습니다</string>
+    <string name="news_source_important">학교 뉴스</string>
+    <string name="news_source_department">학부 공지</string>
+    <string name="news_source_announcement">공지사항</string>
+    <string name="news_source_academic">학술 활동</string>
+    <string name="news_source_default">뉴스</string>
+
+    <!-- Charge error strings -->
+    <string name="charge_error_no_server_public_key">서버 공개키를 가져오지 못했습니다</string>
+    <string name="charge_error_no_payment_info">서버에서 결제 정보를 반환하지 않았습니다</string>
+    <string name="charge_error_empty_payment_data">결제 정보가 비어 있습니다</string>
+    <string name="charge_error_empty_payment_signature">결제 서명이 비어 있습니다</string>
+    <string name="charge_error_parse_failed">결제 정보 분석에 실패했습니다</string>
+    <string name="charge_error_login_required">먼저 로그인하세요</string>
+
+    <!-- Network error messages -->
+    <string name="network_error_forbidden">권한이 부족합니다</string>
+    <string name="network_error_generic">네트워크 오류입니다. 연결을 확인해 주세요</string>
+    <string name="network_error_request_failed">요청에 실패했습니다</string>
+    <string name="network_error_server">서버 오류: %d</string>
+
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1185,6 +1185,9 @@
     <string name="library_collection_result_title">檢索結果</string>
     <string name="library_collection_result_subtitle">共展示 %1$d 條結果</string>
     <string name="library_collection_result_pages">共 %1$d 頁結果</string>
+    <string name="library_page_previous">上一頁</string>
+    <string name="library_page_next">下一頁</string>
+    <string name="library_page_indicator">第 %1$d / %2$d 頁</string>
     <string name="library_collection_detail_title">館藏詳情</string>
     <string name="library_collection_detail_badge">館藏信息</string>
     <string name="library_collection_detail_loading">正在加載館藏詳情…</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1501,4 +1501,29 @@
     <string name="appearance_font_preview">預覽：廣東第二師範學院校園助手</string>
     <string name="appearance_language_label">語言</string>
 
+    <!-- Locale-aware strings -->
+    <string name="home_date_format">M月d日 EEEE</string>
+    <string name="notification_channel_service">系統公告</string>
+    <string name="language_picker_title">語言 / Language</string>
+    <string name="news_error_missing_id">缺少新聞編號</string>
+    <string name="news_source_important">學校要聞</string>
+    <string name="news_source_department">院部通知</string>
+    <string name="news_source_announcement">通知公告</string>
+    <string name="news_source_academic">學術動態</string>
+    <string name="news_source_default">新聞</string>
+
+    <!-- Charge error strings -->
+    <string name="charge_error_no_server_public_key">未能獲取伺服器公鑰</string>
+    <string name="charge_error_no_payment_info">伺服器未返回付款資訊</string>
+    <string name="charge_error_empty_payment_data">付款資訊為空</string>
+    <string name="charge_error_empty_payment_signature">付款簽名為空</string>
+    <string name="charge_error_parse_failed">付款資訊解析失敗</string>
+    <string name="charge_error_login_required">請先登入</string>
+
+    <!-- Network error messages -->
+    <string name="network_error_forbidden">權限不足</string>
+    <string name="network_error_generic">網絡異常，請檢查網絡連接</string>
+    <string name="network_error_request_failed">請求失敗</string>
+    <string name="network_error_server">伺服器錯誤: %d</string>
+
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1185,6 +1185,9 @@
     <string name="library_collection_result_title">檢索結果</string>
     <string name="library_collection_result_subtitle">共展示 %1$d 條結果</string>
     <string name="library_collection_result_pages">共 %1$d 頁結果</string>
+    <string name="library_page_previous">上一頁</string>
+    <string name="library_page_next">下一頁</string>
+    <string name="library_page_indicator">第 %1$d / %2$d 頁</string>
     <string name="library_collection_detail_title">館藏詳情</string>
     <string name="library_collection_detail_badge">館藏訊息</string>
     <string name="library_collection_detail_loading">正在載入館藏詳情…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1501,4 +1501,29 @@
     <string name="appearance_font_preview">預覽：廣東第二師範學院校園助手</string>
     <string name="appearance_language_label">語言</string>
 
+    <!-- Locale-aware strings -->
+    <string name="home_date_format">M月d日 EEEE</string>
+    <string name="notification_channel_service">系統公告</string>
+    <string name="language_picker_title">語言 / Language</string>
+    <string name="news_error_missing_id">缺少新聞編號</string>
+    <string name="news_source_important">學校要聞</string>
+    <string name="news_source_department">院部通知</string>
+    <string name="news_source_announcement">通知公告</string>
+    <string name="news_source_academic">學術動態</string>
+    <string name="news_source_default">新聞</string>
+
+    <!-- Charge error strings -->
+    <string name="charge_error_no_server_public_key">未能取得伺服器公鑰</string>
+    <string name="charge_error_no_payment_info">伺服器未回傳付款資訊</string>
+    <string name="charge_error_empty_payment_data">付款資訊為空</string>
+    <string name="charge_error_empty_payment_signature">付款簽章為空</string>
+    <string name="charge_error_parse_failed">付款資訊解析失敗</string>
+    <string name="charge_error_login_required">請先登入</string>
+
+    <!-- Network error messages -->
+    <string name="network_error_forbidden">權限不足</string>
+    <string name="network_error_generic">網路異常，請檢查網路連線</string>
+    <string name="network_error_request_failed">請求失敗</string>
+    <string name="network_error_server">伺服器錯誤: %d</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1502,4 +1502,29 @@
     <string name="appearance_font_preview">预览：广东第二师范学院校园助手</string>
     <string name="appearance_language_label">语言</string>
 
+    <!-- Locale-aware strings -->
+    <string name="home_date_format">M月d日 EEEE</string>
+    <string name="notification_channel_service">系统公告</string>
+    <string name="language_picker_title">语言 / Language</string>
+    <string name="news_error_missing_id">缺少新闻编号</string>
+    <string name="news_source_important">学校要闻</string>
+    <string name="news_source_department">院部通知</string>
+    <string name="news_source_announcement">通知公告</string>
+    <string name="news_source_academic">学术动态</string>
+    <string name="news_source_default">新闻</string>
+
+    <!-- Charge error strings -->
+    <string name="charge_error_no_server_public_key">未获取到服务端公钥</string>
+    <string name="charge_error_no_payment_info">服务端未返回支付信息</string>
+    <string name="charge_error_empty_payment_data">支付信息为空</string>
+    <string name="charge_error_empty_payment_signature">支付签名为空</string>
+    <string name="charge_error_parse_failed">支付信息解析失败</string>
+    <string name="charge_error_login_required">请先登录</string>
+
+    <!-- Network error messages -->
+    <string name="network_error_forbidden">权限不足</string>
+    <string name="network_error_generic">网络异常，请检查网络连接</string>
+    <string name="network_error_request_failed">请求失败</string>
+    <string name="network_error_server">服务器错误: %d</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1185,6 +1185,9 @@
     <string name="library_collection_result_title">检索结果</string>
     <string name="library_collection_result_subtitle">共展示 %1$d 条结果</string>
     <string name="library_collection_result_pages">共 %1$d 页结果</string>
+    <string name="library_page_previous">上一页</string>
+    <string name="library_page_next">下一页</string>
+    <string name="library_page_indicator">第 %1$d / %2$d 页</string>
     <string name="library_collection_detail_title">馆藏详情</string>
     <string name="library_collection_detail_badge">馆藏信息</string>
     <string name="library_collection_detail_loading">正在加载馆藏详情…</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,10 @@ jwtdecode = "1.2.0"
 androidx-junit = "1.1.5"
 coil = "2.7.0"
 security-crypto = "1.1.0-alpha06"
+appcompat = "1.7.0"
 
 [libraries]
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }


### PR DESCRIPTION
## Summary
- Apply locale via AppCompatDelegate.setApplicationLocales() in MainActivity
- Replace hardcoded Chinese across UI, network layer, and charge flow
- Add AppContextProvider with null-safe contextOrNull for string resources
- Send X-Device-ID header for server-side device binding
- Add library search pagination with prev/next controls
- Fix Client-Type to X-Client-Type in ChargeApi
- Add androidx.appcompat:1.7.0 dependency (fixes compilation failure)

## Test plan
- [ ] `./gradlew testDebugUnitTest` compiles and passes
- [ ] Language switch updates all stringResource() text
- [ ] Library search pagination works
- [ ] Requests include X-Device-ID header

🤖 Generated with [Claude Code](https://claude.com/claude-code)