### PR TITLE
Remove misleading delivery hall status filter

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/delivery/DeliveryScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/delivery/DeliveryScreen.kt
@@ -92,17 +92,6 @@ fun DeliveryScreen(navController: NavHostController) {
                 )
             }
         }
-        item {
-            androidx.compose.foundation.layout.Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                DeliveryFilter.entries.forEach { filter ->
-                    FilterChip(
-                        selected = state.selectedFilter == filter,
-                        onClick = { viewModel.selectFilter(filter) },
-                        label = { Text(text = deliveryFilterLabel(filter)) }
-                    )
-                }
-            }
-        }
         if (!state.error.isNullOrBlank()) {
             item {
                 StatusBanner(
@@ -114,7 +103,7 @@ fun DeliveryScreen(navController: NavHostController) {
         }
         when {
             state.isLoading && state.orders.isEmpty() -> item { DeliveryLoadingPane() }
-            state.visibleOrders.isEmpty() -> item {
+            state.orders.isEmpty() -> item {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -128,7 +117,7 @@ fun DeliveryScreen(navController: NavHostController) {
                 }
             }
             else -> {
-                items(state.visibleOrders, key = { it.orderId }) { order ->
+                items(state.orders, key = { it.orderId }) { order ->
                     DeliveryOrderCard(
                         order = order,
                         onClick = { navController.navigate(Routes.deliveryDetail(order.orderId)) }

--- a/app/src/main/java/cn/gdeiassistant/ui/delivery/DeliveryViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/delivery/DeliveryViewModel.kt
@@ -35,13 +35,9 @@ enum class DeliveryMineTab {
 data class DeliveryUiState(
     val orders: List<DeliveryOrder> = emptyList(),
     val mine: DeliveryMineSummary = DeliveryMineSummary(emptyList(), emptyList()),
-    val selectedFilter: DeliveryFilter = DeliveryFilter.ALL,
     val isLoading: Boolean = true,
     val error: String? = null
-) {
-    val visibleOrders: List<DeliveryOrder>
-        get() = orders.filterBy(selectedFilter)
-}
+)
 
 data class DeliveryDetailUiState(
     val detail: DeliveryOrderDetail? = null,
@@ -95,10 +91,6 @@ class DeliveryViewModel @Inject constructor(
 
     init {
         refresh()
-    }
-
-    fun selectFilter(filter: DeliveryFilter) {
-        _state.update { it.copy(selectedFilter = filter) }
     }
 
     fun refresh() {


### PR DESCRIPTION
## Summary
- Remove filter chips from delivery hall screen — backend only returns pending (state=0) orders

## Test plan
- [ ] Delivery hall shows pending orders without filter tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)