### PR TITLE
Add TalkBack semantics and localize state descriptions

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
@@ -16,6 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -45,7 +49,13 @@ fun BentoCard(
         )
         .clip(AppShapes.card)
         .background(containerColor)
-        .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+        .then(
+            if (onClick != null)
+                Modifier
+                    .semantics { role = Role.Button }
+                    .clickable { onClick() }
+            else Modifier
+        )
         .padding(contentPadding)
 
     Column(modifier = cardModifier) {
@@ -322,6 +332,10 @@ fun TextTabSelector(
                     modifier = Modifier
                         .weight(1f)
                         .clip(AppShapes.small)
+                        .semantics {
+                            role = Role.Tab
+                            this.selected = selected
+                        }
                         .clickable { onSelect(index) }
                         .padding(horizontal = 8.dp, vertical = 6.dp),
                     horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
@@ -83,7 +83,7 @@ private fun LanguageRow(
             .semantics {
                 role = Role.RadioButton
                 this.selected = selected
-                stateDescription = if (selected) "Selected" else "Not selected"
+                stateDescription = stringResource(if (selected) R.string.accessibility_selected else R.string.accessibility_not_selected)
             }
             .clickable(onClick = onClick)
             .padding(horizontal = 20.dp, vertical = 16.dp),

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
@@ -16,6 +16,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
@@ -75,6 +80,11 @@ private fun LanguageRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics {
+                role = Role.RadioButton
+                this.selected = selected
+                stateDescription = if (selected) "Selected" else "Not selected"
+            }
             .clickable(onClick = onClick)
             .padding(horizontal = 20.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1530,5 +1530,7 @@
     <string name="network_error_generic">Network error. Please check your connection.</string>
     <string name="network_error_request_failed">Request failed</string>
     <string name="network_error_server">Server error: %d</string>
+    <string name="accessibility_selected">Selected</string>
+    <string name="accessibility_not_selected">Not selected</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1529,5 +1529,7 @@
     <string name="network_error_generic">ネットワークエラーです。接続を確認してください</string>
     <string name="network_error_request_failed">リクエストに失敗しました</string>
     <string name="network_error_server">サーバーエラー: %d</string>
+    <string name="accessibility_selected">選択済み</string>
+    <string name="accessibility_not_selected">未選択</string>
 
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1529,5 +1529,7 @@
     <string name="network_error_generic">네트워크 오류입니다. 연결을 확인해 주세요</string>
     <string name="network_error_request_failed">요청에 실패했습니다</string>
     <string name="network_error_server">서버 오류: %d</string>
+    <string name="accessibility_selected">선택됨</string>
+    <string name="accessibility_not_selected">선택 안 됨</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1528,5 +1528,7 @@
     <string name="network_error_generic">網絡異常，請檢查網絡連接</string>
     <string name="network_error_request_failed">請求失敗</string>
     <string name="network_error_server">伺服器錯誤: %d</string>
+    <string name="accessibility_selected">已選擇</string>
+    <string name="accessibility_not_selected">未選擇</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1528,5 +1528,7 @@
     <string name="network_error_generic">網路異常，請檢查網路連線</string>
     <string name="network_error_request_failed">請求失敗</string>
     <string name="network_error_server">伺服器錯誤: %d</string>
+    <string name="accessibility_selected">已選擇</string>
+    <string name="accessibility_not_selected">未選擇</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1529,5 +1529,7 @@
     <string name="network_error_generic">网络异常，请检查网络连接</string>
     <string name="network_error_request_failed">请求失败</string>
     <string name="network_error_server">服务器错误: %d</string>
+    <string name="accessibility_selected">已选择</string>
+    <string name="accessibility_not_selected">未选择</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- BentoCard: add Role.Button semantics for clickable cards
- TextTabSelector: add Role.Tab with selected state
- LanguagePickerScreen: add Role.RadioButton with localized stateDescription

## Test plan
- [ ] TalkBack announces correct roles for cards, tabs, and language rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)