### PR TITLE
refactor: remove user-facing error messages from DatingRepository

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/DatingRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/DatingRepository.kt
@@ -50,7 +50,7 @@ class DatingRepository @Inject constructor(
     suspend fun getProfileDetail(id: String): Result<DatingProfileDetail> = withContext(Dispatchers.IO) {
         safeApiCall { datingApi.getProfileDetail(id) }
             .mapCatching { dto ->
-                val profileDto = dto?.profile ?: throw IllegalStateException("未找到卖室友资料")
+                val profileDto = dto?.profile ?: throw NoSuchElementException("dating_profile_not_found")
                 mapProfileDetail(profileDto, dto)
             }
     }
@@ -182,7 +182,7 @@ class DatingRepository @Inject constructor(
     private fun Uri.toPart(): MultipartBody.Part {
         val mimeType = context.contentResolver.getType(this)?.ifBlank { null } ?: "image/jpeg"
         val bytes = context.contentResolver.openInputStream(this)?.use { it.readBytes() }
-            ?: throw IllegalStateException("Failed to read image data")
+            ?: throw IllegalStateException("image_read_failed")
         return MultipartBody.Part.createFormData(
             "image",
             queryDisplayName(this).ifBlank { "dating-${UUID.randomUUID()}.jpg" },

--- a/app/src/main/java/cn/gdeiassistant/ui/dating/DatingModuleViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/dating/DatingModuleViewModels.kt
@@ -140,7 +140,7 @@ class DatingDetailViewModel @Inject constructor(
                         it.copy(
                             detail = null,
                             isLoading = false,
-                            error = error.message
+                            error = context.getString(R.string.dating_detail_load_failed)
                         )
                     }
                 }
@@ -248,8 +248,9 @@ class DatingPublishViewModel @Inject constructor(
                         _events.emit(DatingModuleEvent.ShowMessage(context.getString(R.string.dating_publish_success)))
                         _events.emit(DatingModuleEvent.Submitted)
                     }.onFailure { error ->
-                        _state.update { it.copy(isSubmitting = false, error = error.message) }
-                        emitMessage(error.message ?: context.getString(R.string.dating_publish_failed))
+                        val msg = context.getString(R.string.dating_publish_failed)
+                        _state.update { it.copy(isSubmitting = false, error = msg) }
+                        emitMessage(msg)
                     }
                 }
             }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -936,6 +936,7 @@
     <string name="dating_publish_wechat_too_long">WeChat cannot exceed 20 characters</string>
     <string name="dating_publish_success">Profile published</string>
     <string name="dating_publish_failed">Failed to publish profile</string>
+    <string name="dating_detail_load_failed">Failed to load profile</string>
     <string name="dating_publish_read_failed">Failed to read photo</string>
     <string name="dating_loading_title">Loading</string>
     <string name="dating_loading_hint">Syncing profiles and interaction status…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -936,6 +936,7 @@
     <string name="dating_publish_wechat_too_long">WeChat は20文字以内で入力してください</string>
     <string name="dating_publish_success">プロフィールが投稿されました</string>
     <string name="dating_publish_failed">プロフィールの投稿に失敗しました</string>
+    <string name="dating_detail_load_failed">プロフィール読み込み失敗</string>
     <string name="dating_publish_read_failed">画像の読み込みに失敗しました</string>
     <string name="dating_loading_title">読み込み中</string>
     <string name="dating_loading_hint">ルームメイト紹介のプロフィールとインタラクション状態を同期中…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -936,6 +936,7 @@
     <string name="dating_publish_wechat_too_long">위챗은 20자를 초과할 수 없습니다</string>
     <string name="dating_publish_success">프로필이 등록되었습니다</string>
     <string name="dating_publish_failed">프로필 등록 실패</string>
+    <string name="dating_detail_load_failed">프로필 로드 실패</string>
     <string name="dating_publish_read_failed">이미지 읽기 실패</string>
     <string name="dating_loading_title">로딩 중</string>
     <string name="dating_loading_hint">룸메이트 소개 프로필 및 소통 상태 동기화 중…</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -935,6 +935,7 @@
     <string name="dating_publish_wechat_too_long">微信不能超過 20 個字符</string>
     <string name="dating_publish_success">資料發佈成功</string>
     <string name="dating_publish_failed">資料發佈失敗</string>
+    <string name="dating_detail_load_failed">載入資料失敗</string>
     <string name="dating_publish_read_failed">讀取圖片失敗</string>
     <string name="dating_loading_title">正在加載</string>
     <string name="dating_loading_hint">正在同步賣室友資料和互動狀態…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -935,6 +935,7 @@
     <string name="dating_publish_wechat_too_long">微信不能超過 20 個字元</string>
     <string name="dating_publish_success">資料發佈成功</string>
     <string name="dating_publish_failed">資料發佈失敗</string>
+    <string name="dating_detail_load_failed">載入資料失敗</string>
     <string name="dating_publish_read_failed">讀取圖片失敗</string>
     <string name="dating_loading_title">正在載入</string>
     <string name="dating_loading_hint">正在同步賣室友資料和互動狀態…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -935,6 +935,7 @@
     <string name="dating_publish_wechat_too_long">微信不能超过 20 个字符</string>
     <string name="dating_publish_success">资料发布成功</string>
     <string name="dating_publish_failed">资料发布失败</string>
+    <string name="dating_detail_load_failed">加载资料失败</string>
     <string name="dating_publish_read_failed">读取图片失败</string>
     <string name="dating_loading_title">正在加载</string>
     <string name="dating_loading_hint">正在同步卖室友资料和互动状态…</string>


### PR DESCRIPTION
## Summary
- Replace hardcoded Chinese/English exception messages with neutral error keys
- ViewModel error paths use localized string resources instead of raw exception.message
- Add dating_detail_load_failed to all 6 locale files

## Test plan
- [x] `./gradlew testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)