### PR TITLE
refactor: localize remaining Dating error display paths

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/dating/DatingModuleViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/dating/DatingModuleViewModels.kt
@@ -161,9 +161,10 @@ class DatingDetailViewModel @Inject constructor(
                             _events.emit(DatingModuleEvent.ShowMessage(context.getString(R.string.dating_pick_success)))
                             refresh()
                         }
-                        .onFailure { error ->
-                            _state.update { it.copy(isSubmitting = false, error = error.message) }
-                            emitMessage(error.message ?: context.getString(R.string.dating_pick_failed))
+                        .onFailure { _ ->
+                            val msg = context.getString(R.string.dating_pick_failed)
+                            _state.update { it.copy(isSubmitting = false, error = msg) }
+                            emitMessage(msg)
                         }
                 }
             }

--- a/app/src/main/java/cn/gdeiassistant/ui/dating/DatingViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/dating/DatingViewModel.kt
@@ -109,11 +109,9 @@ class DatingViewModel @Inject constructor(
                     )
                     refresh()
                 }
-                .onFailure { error ->
+                .onFailure { _ ->
                     _events.emit(
-                        DatingEvent.ShowMessage(
-                            error.message ?: context.getString(R.string.dating_toast_failed)
-                        )
+                        DatingEvent.ShowMessage(context.getString(R.string.dating_toast_failed))
                     )
                 }
         }
@@ -126,11 +124,9 @@ class DatingViewModel @Inject constructor(
                     _events.emit(DatingEvent.ShowMessage(context.getString(R.string.dating_toast_hidden)))
                     refresh()
                 }
-                .onFailure { error ->
+                .onFailure { _ ->
                     _events.emit(
-                        DatingEvent.ShowMessage(
-                            error.message ?: context.getString(R.string.dating_toast_hide_failed)
-                        )
+                        DatingEvent.ShowMessage(context.getString(R.string.dating_toast_hide_failed))
                     )
             }
         }


### PR DESCRIPTION
## Summary
- submitPick, updatePickState, hideProfile: replace error.message with string resources

## Test plan
- [x] `./gradlew testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)