### PR TITLE
feat: migrate secret profile to paginated endpoint

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/SecretRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/SecretRepository.kt
@@ -37,8 +37,8 @@ class SecretRepository @Inject constructor(
             }
     }
 
-    suspend fun getMyPosts(): Result<List<SecretPost>> = withContext(Dispatchers.IO) {
-        safeApiCall { secretApi.getMyPosts() }
+    suspend fun getMyPosts(start: Int = 0, size: Int = 20): Result<List<SecretPost>> = withContext(Dispatchers.IO) {
+        safeApiCall { secretApi.getMyPosts(start = start, size = size) }
             .mapCatching { items ->
                 items.orEmpty()
                     .filter { (it.state ?: 0) != 2 }

--- a/app/src/main/java/cn/gdeiassistant/network/api/SecretApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/SecretApi.kt
@@ -19,8 +19,11 @@ interface SecretApi {
         @Path("size") size: Int
     ): DataJsonResult<List<SecretPostDto>>
 
-    @GET("api/secret/profile")
-    suspend fun getMyPosts(): DataJsonResult<List<SecretPostDto>>
+    @GET("api/secret/profile/start/{start}/size/{size}")
+    suspend fun getMyPosts(
+        @Path("start") start: Int,
+        @Path("size") size: Int
+    ): DataJsonResult<List<SecretPostDto>>
 
     @GET("api/secret/id/{id}")
     suspend fun getDetail(

--- a/app/src/main/java/cn/gdeiassistant/ui/secret/SecretProfileViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/secret/SecretProfileViewModel.kt
@@ -16,6 +16,8 @@ import javax.inject.Inject
 data class SecretProfileUiState(
     val items: List<SecretPost> = emptyList(),
     val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val hasMore: Boolean = true,
     val error: String? = null
 )
 
@@ -25,6 +27,7 @@ class SecretProfileViewModel @Inject constructor(
     private val displayMapper: SecretDisplayMapper
 ) : ViewModel() {
 
+    private val pageSize = 20
     private val _state = MutableStateFlow(SecretProfileUiState())
     val state: StateFlow<SecretProfileUiState> = _state.asStateFlow()
 
@@ -35,13 +38,43 @@ class SecretProfileViewModel @Inject constructor(
     fun refresh() {
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null) }
-            secretRepository.getMyPosts()
+            secretRepository.getMyPosts(start = 0, size = pageSize)
                 .map { displayMapper.applyPostDefaults(it) }
                 .onSuccess { items ->
-                    _state.update { it.copy(items = items, isLoading = false, error = null) }
+                    _state.update {
+                        it.copy(
+                            items = items,
+                            isLoading = false,
+                            hasMore = items.size >= pageSize,
+                            error = null
+                        )
+                    }
                 }
                 .onFailure { error ->
                     _state.update { it.copy(items = emptyList(), isLoading = false, error = error.message) }
+                }
+        }
+    }
+
+    fun loadMore() {
+        val current = _state.value
+        if (current.isLoadingMore || !current.hasMore) return
+
+        viewModelScope.launch {
+            _state.update { it.copy(isLoadingMore = true) }
+            secretRepository.getMyPosts(start = current.items.size, size = pageSize)
+                .map { displayMapper.applyPostDefaults(it) }
+                .onSuccess { newItems ->
+                    _state.update {
+                        it.copy(
+                            items = it.items + newItems,
+                            isLoadingMore = false,
+                            hasMore = newItems.size >= pageSize
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _state.update { it.copy(isLoadingMore = false, error = error.message) }
                 }
         }
     }


### PR DESCRIPTION
## Summary
- SecretApi/Repository/ViewModel: use paginated endpoint with load more

🤖 Generated with [Claude Code](https://claude.com/claude-code)