### PR TITLE
feat: request correlation, network logging, tests, CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,55 @@
+name: Android CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - 'release/**'
+  pull_request:
+    branches:
+      - main
+      - master
+      - 'release/**'
+
+jobs:
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: gradle-android-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: |
+            gradle-android-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-reports
+          path: |
+            app/build/reports/tests/
+            app/build/test-results/
+          retention-days: 7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.espresso.core)
 }

--- a/app/src/main/java/cn/gdeiassistant/di/NetworkModule.kt
+++ b/app/src/main/java/cn/gdeiassistant/di/NetworkModule.kt
@@ -7,6 +7,8 @@ import cn.gdeiassistant.network.BaseUrlOverrideInterceptor
 import cn.gdeiassistant.network.LocaleInterceptor
 import cn.gdeiassistant.network.MockInterceptor
 import cn.gdeiassistant.network.NetworkConstants
+import cn.gdeiassistant.network.NetworkLoggingInterceptor
+import cn.gdeiassistant.network.RequestIdInterceptor
 import cn.gdeiassistant.network.ResponseInterceptor
 import cn.gdeiassistant.network.api.AnnouncementApi
 import cn.gdeiassistant.network.api.AuthApi
@@ -48,8 +50,18 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    fun provideRequestIdInterceptor(): RequestIdInterceptor = RequestIdInterceptor()
+
+    @Provides
+    @Singleton
+    fun provideNetworkLoggingInterceptor(): NetworkLoggingInterceptor = NetworkLoggingInterceptor()
+
+    @Provides
+    @Singleton
     fun provideOkHttpClient(
         sessionManager: SessionManager,
+        requestIdInterceptor: RequestIdInterceptor,
+        networkLoggingInterceptor: NetworkLoggingInterceptor,
         baseUrlOverrideInterceptor: BaseUrlOverrideInterceptor,
         authInterceptor: AuthInterceptor,
         responseInterceptor: ResponseInterceptor,
@@ -59,11 +71,13 @@ object NetworkModule {
         .readTimeout(NetworkConstants.READ_WRITE_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
         .writeTimeout(NetworkConstants.READ_WRITE_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
         .cookieJar(sessionManager.cookieJar)
-        .addInterceptor(localeInterceptor)
-        .addInterceptor(baseUrlOverrideInterceptor)
-        .addInterceptor(MockInterceptor())
-        .addInterceptor(authInterceptor)
-        .addInterceptor(responseInterceptor)
+        .addInterceptor(requestIdInterceptor)        // 1. Assign X-Request-ID before anything else
+        .addInterceptor(localeInterceptor)           // 2. Add Accept-Language
+        .addInterceptor(baseUrlOverrideInterceptor)  // 3. Rewrite base URL for environment
+        .addInterceptor(networkLoggingInterceptor)   // 4. Log request+response timing
+        .addInterceptor(MockInterceptor())           // 5. Short-circuit with mock data if enabled
+        .addInterceptor(authInterceptor)             // 6. Attach Bearer token
+        .addInterceptor(responseInterceptor)         // 7. Handle HTTP errors
         .build()
 
     @Provides

--- a/app/src/main/java/cn/gdeiassistant/network/NetworkLoggingInterceptor.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/NetworkLoggingInterceptor.kt
@@ -1,0 +1,57 @@
+package cn.gdeiassistant.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.logging.Logger
+import javax.inject.Inject
+
+/**
+ * Application interceptor that logs each HTTP exchange: request ID, method, URL path,
+ * HTTP status code, and round-trip elapsed time.
+ *
+ * Request/response bodies are intentionally not logged to keep production logs
+ * lightweight and avoid accidentally leaking sensitive payloads.
+ *
+ * The [X-Request-ID] header is expected to have been set by [RequestIdInterceptor] earlier in
+ * the chain. If the backend echoes a different request ID in the response, both IDs are logged
+ * so that client-side and server-side logs can be correlated.
+ */
+class NetworkLoggingInterceptor @Inject constructor() : Interceptor {
+
+    private val logger = Logger.getLogger("GdeiNetwork")
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val requestId = request.header("X-Request-ID") ?: "?"
+        val method = request.method
+        val path = request.url.encodedPath
+
+        val start = System.currentTimeMillis()
+        val response: Response
+        try {
+            response = chain.proceed(request)
+        } catch (e: AppException) {
+            // AppException is thrown by ResponseInterceptor for 4xx/5xx responses.
+            // e.code is the HTTP status code — log it as a structured field rather than "FAILED".
+            // The backend-echoed X-Request-ID is unavailable here because ResponseInterceptor
+            // consumed the raw response before throwing; log what we have.
+            val elapsed = System.currentTimeMillis() - start
+            logger.warning("rid:$requestId | $method $path | ${e.code} | ${elapsed}ms | error")
+            throw e
+        } catch (e: Exception) {
+            val elapsed = System.currentTimeMillis() - start
+            logger.warning("rid:$requestId | $method $path | FAILED | ${elapsed}ms | ${e.javaClass.simpleName}")
+            throw e
+        }
+
+        val elapsed = System.currentTimeMillis() - start
+        val status = response.code
+        val backendRid = response.header("X-Request-ID")
+        if (backendRid != null) {
+            logger.info("client-rid:$requestId backend-rid:$backendRid | $method $path | $status | ${elapsed}ms")
+        } else {
+            logger.info("rid:$requestId | $method $path | $status | ${elapsed}ms")
+        }
+        return response
+    }
+}

--- a/app/src/main/java/cn/gdeiassistant/network/RequestIdInterceptor.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/RequestIdInterceptor.kt
@@ -1,0 +1,28 @@
+package cn.gdeiassistant.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Application interceptor that attaches a per-request [X-Request-ID] header to every outgoing
+ * call so that it can be correlated with backend logs.
+ *
+ * If the request already carries an [X-Request-ID] header (e.g., set by a test or an upstream
+ * proxy), the existing value is kept unchanged to preserve end-to-end traceability.
+ */
+class RequestIdInterceptor @Inject constructor() : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+        val request = if (original.header("X-Request-ID").isNullOrBlank()) {
+            original.newBuilder()
+                .header("X-Request-ID", UUID.randomUUID().toString())
+                .build()
+        } else {
+            original
+        }
+        return chain.proceed(request)
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/data/AuthRepositoryContractTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/AuthRepositoryContractTest.kt
@@ -1,0 +1,108 @@
+package cn.gdeiassistant.data
+
+import cn.gdeiassistant.model.DataJsonResult
+import cn.gdeiassistant.model.UserLoginResult
+import cn.gdeiassistant.network.AppException
+import cn.gdeiassistant.network.api.AuthApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Contract tests for [AuthRepository]: verifies that the repository correctly maps
+ * [AuthApi] responses to [Result] and delegates token persistence to [SessionManager].
+ *
+ * These tests operate at the repository level using mocked API/session dependencies.
+ * They do not require Android context for the tested paths.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthRepositoryContractTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var authApi: AuthApi
+    private lateinit var sessionManager: SessionManager
+    private lateinit var authRepository: AuthRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        authApi = mock()
+        sessionManager = mock()
+        authRepository = AuthRepository(
+            context = mock(),
+            authApi = authApi,
+            sessionManager = sessionManager
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loginSuccessTokenIsSavedAndResultIsSuccess() = runTest(testDispatcher) {
+        val token = "eyJhbGciOiJIUzI1NiJ9.test.signature"
+        whenever(authApi.login(any())).thenReturn(
+            DataJsonResult(success = true, code = 200, data = UserLoginResult(token = token))
+        )
+
+        val result = authRepository.login("testuser", "password123")
+
+        assertTrue("Expected success result", result.isSuccess)
+        verify(sessionManager).saveToken(token, "testuser")
+    }
+
+    @Test
+    fun loginSuccessTrimsUsernameBeforeSaving() = runTest(testDispatcher) {
+        val token = "valid-token"
+        whenever(authApi.login(any())).thenReturn(
+            DataJsonResult(success = true, code = 200, data = UserLoginResult(token = token))
+        )
+
+        authRepository.login("  testuser  ", "password")
+
+        verify(sessionManager).saveToken(token, "testuser")
+    }
+
+    @Test
+    fun loginServerRejectionReturnsFailureWithBackendMessage() = runTest(testDispatcher) {
+        whenever(authApi.login(any())).thenReturn(
+            DataJsonResult(
+                success = false,
+                code = 401,
+                message = "用户名或密码错误"
+            )
+        )
+
+        val result = authRepository.login("testuser", "wrongpassword")
+
+        assertTrue("Expected failure result", result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue("Exception should be AppException", exception is AppException)
+        assertEquals("用户名或密码错误", exception?.message)
+    }
+
+    @Test
+    fun loginApiCallIncludesUsernameAndPassword() = runTest(testDispatcher) {
+        whenever(authApi.login(any())).thenReturn(
+            DataJsonResult(success = true, code = 200, data = UserLoginResult(token = "tok"))
+        )
+
+        authRepository.login("alice", "s3cret")
+
+        verify(authApi).login(mapOf("username" to "alice", "password" to "s3cret"))
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/data/MarketplaceSearchTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/MarketplaceSearchTest.kt
@@ -5,6 +5,7 @@ import cn.gdeiassistant.model.MarketplaceItem
 import cn.gdeiassistant.model.MarketplaceItemState
 import cn.gdeiassistant.network.api.MarketplaceApi
 import cn.gdeiassistant.network.api.MarketplaceItemDto
+import cn.gdeiassistant.network.api.ProfileApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -110,6 +111,75 @@ class MarketplaceSearchTest {
         val keyword = "   "
         val normalizedKeyword = keyword.trim()
         assertTrue(normalizedKeyword.isBlank())
+    }
+
+    // ---------------------------------------------------------------
+    // Repository-level contract assertions
+    // ---------------------------------------------------------------
+
+    private fun createRepository(): MarketplaceRepository = MarketplaceRepository(
+        context = mock(),
+        marketplaceApi = marketplaceApi,
+        profileRepository = mock(),
+        profileOptionsRepository = ProfileOptionsRepository(mock<ProfileApi>())
+    )
+
+    @Test
+    fun repositoryRoutesKeywordSearchToSearchEndpoint() = runTest(testDispatcher) {
+        whenever(marketplaceApi.searchItems(keyword = "笔记本", start = 0))
+            .thenReturn(successResponse)
+
+        val result = createRepository().getItems(keyword = "笔记本")
+
+        assertTrue(result.isSuccess)
+        verify(marketplaceApi).searchItems(keyword = "笔记本", start = 0)
+        verify(marketplaceApi, never()).getItems(start = any())
+        verify(marketplaceApi, never()).getItemsByType(type = any(), start = any())
+    }
+
+    @Test
+    fun repositoryRoutesTypeFilterToTypeEndpoint() = runTest(testDispatcher) {
+        whenever(marketplaceApi.getItemsByType(type = 3, start = 0))
+            .thenReturn(successResponse)
+
+        val result = createRepository().getItems(typeId = 3)
+
+        assertTrue(result.isSuccess)
+        verify(marketplaceApi).getItemsByType(type = 3, start = 0)
+        verify(marketplaceApi, never()).getItems(start = any())
+        verify(marketplaceApi, never()).searchItems(keyword = any(), start = any())
+    }
+
+    @Test
+    fun repositoryFiltersOutNonSellingItems() = runTest(testDispatcher) {
+        val mixed = DataJsonResult(
+            success = true, code = 200,
+            data = listOf(
+                sellingDto.copy(id = 1, state = 1),  // SELLING  — should be kept
+                sellingDto.copy(id = 2, state = 0),  // not selling — should be filtered
+                sellingDto.copy(id = 3, state = 2),  // off — should be filtered
+            )
+        )
+        whenever(marketplaceApi.getItems(start = 0)).thenReturn(mixed)
+
+        val result = createRepository().getItems()
+
+        assertTrue(result.isSuccess)
+        val items = result.getOrThrow()
+        assertEquals(1, items.size)
+        assertEquals("1", items.first().id)
+    }
+
+    @Test
+    fun repositoryReturnsEmptyListWhenApiReturnsEmptyData() = runTest(testDispatcher) {
+        whenever(marketplaceApi.getItems(start = 0)).thenReturn(
+            DataJsonResult(success = true, code = 200, data = emptyList())
+        )
+
+        val result = createRepository().getItems()
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
     }
 
     @Test

--- a/app/src/test/java/cn/gdeiassistant/network/NetworkLoggingInterceptorTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/NetworkLoggingInterceptorTest.kt
@@ -1,0 +1,160 @@
+package cn.gdeiassistant.network
+
+import cn.gdeiassistant.data.SessionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+
+/**
+ * Verifies that [NetworkLoggingInterceptor] emits structured log records for both
+ * successful and error HTTP responses.
+ *
+ * Tests use a chain of [RequestIdInterceptor] + [NetworkLoggingInterceptor] +
+ * [ResponseInterceptor] backed by [MockWebServer] so that the real interceptor
+ * interaction is exercised end-to-end.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NetworkLoggingInterceptorTest {
+
+    private val server = MockWebServer()
+    private val testDispatcher = StandardTestDispatcher()
+
+    // Capture java.util.logging records emitted by NetworkLoggingInterceptor
+    private val capturedMessages = mutableListOf<String>()
+    private val logHandler = object : Handler() {
+        override fun publish(record: LogRecord) { capturedMessages.add(record.message ?: "") }
+        override fun flush() {}
+        override fun close() {}
+    }
+    private val networkLogger = java.util.logging.Logger.getLogger("GdeiNetwork")
+
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        server.start()
+        capturedMessages.clear()
+        networkLogger.addHandler(logHandler)
+
+        client = OkHttpClient.Builder()
+            .addInterceptor(RequestIdInterceptor())
+            .addInterceptor(NetworkLoggingInterceptor())
+            .addInterceptor(ResponseInterceptor(mock<SessionManager>()))
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        networkLogger.removeHandler(logHandler)
+        Dispatchers.resetMain()
+        server.shutdown()
+    }
+
+    @Test
+    fun successResponseLogsStatusCode200AndRequestId() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client.newCall(
+            Request.Builder()
+                .url(server.url("/api/test"))
+                .header("X-Request-ID", "success-rid-001")
+                .build()
+        ).execute().close()
+
+        assertTrue(
+            "Expected a log entry containing '200'",
+            capturedMessages.any { it.contains("200") }
+        )
+        assertTrue(
+            "Expected a log entry containing the request ID",
+            capturedMessages.any { it.contains("success-rid-001") }
+        )
+    }
+
+    @Test
+    fun errorResponseLogsActualStatusCodeNotFailed() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(403)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"success":false,"message":"无权访问"}""")
+        )
+
+        try {
+            client.newCall(
+                Request.Builder()
+                    .url(server.url("/api/admin"))
+                    .header("X-Request-ID", "error-rid-002")
+                    .build()
+            ).execute()
+        } catch (_: AppException) { /* expected */ }
+
+        assertTrue(
+            "Expected a log entry containing '403' (not just 'FAILED')",
+            capturedMessages.any { it.contains("403") }
+        )
+        assertTrue(
+            "Expected the log entry for the error to NOT use the bare 'FAILED' label",
+            capturedMessages.none { it.contains("FAILED") }
+        )
+    }
+
+    @Test
+    fun errorResponseLogsRequestIdForCorrelation() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"success":false,"message":"Token expired"}""")
+        )
+
+        try {
+            client.newCall(
+                Request.Builder()
+                    .url(server.url("/api/profile"))
+                    .header("X-Request-ID", "corr-rid-003")
+                    .build()
+            ).execute()
+        } catch (_: AppException) { /* expected */ }
+
+        assertTrue(
+            "Expected the error log entry to include the request ID for correlation",
+            capturedMessages.any { msg -> msg.contains("corr-rid-003") && msg.contains("401") }
+        )
+    }
+
+    @Test
+    fun successResponseWithBackendRidLogsBothIds() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("X-Request-ID", "backend-echo-999")
+        )
+
+        client.newCall(
+            Request.Builder()
+                .url(server.url("/api/items"))
+                .header("X-Request-ID", "client-rid-004")
+                .build()
+        ).execute().close()
+
+        assertTrue(
+            "Expected log entry with both client and backend request IDs",
+            capturedMessages.any { it.contains("client-rid-004") && it.contains("backend-echo-999") }
+        )
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/network/RequestIdInterceptorTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/RequestIdInterceptorTest.kt
@@ -1,0 +1,87 @@
+package cn.gdeiassistant.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RequestIdInterceptorTest {
+
+    private val server = MockWebServer()
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server.start()
+        client = OkHttpClient.Builder()
+            .addInterceptor(RequestIdInterceptor())
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun injectsRequestIdWhenAbsent() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute().close()
+
+        val recorded = server.takeRequest()
+        val rid = recorded.getHeader("X-Request-ID")
+        assertNotNull("X-Request-ID header should be present", rid)
+        assertTrue("X-Request-ID should be non-blank", rid!!.isNotBlank())
+    }
+
+    @Test
+    fun generatedIdMatchesUuidFormat() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute().close()
+
+        val rid = server.takeRequest().getHeader("X-Request-ID")!!
+        // UUID: 8-4-4-4-12 lowercase hex digits separated by hyphens
+        assertTrue(
+            "X-Request-ID should be UUID format, was: $rid",
+            rid.matches(Regex("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"))
+        )
+    }
+
+    @Test
+    fun doesNotOverwriteExistingRequestId() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val existingId = "test-client-id-001"
+        client.newCall(
+            Request.Builder()
+                .url(server.url("/api/test"))
+                .header("X-Request-ID", existingId)
+                .build()
+        ).execute().close()
+
+        assertEquals(existingId, server.takeRequest().getHeader("X-Request-ID"))
+    }
+
+    @Test
+    fun eachRequestReceivesDifferentId() {
+        server.enqueue(MockResponse().setResponseCode(200))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val url = server.url("/api/test")
+        client.newCall(Request.Builder().url(url).build()).execute().close()
+        client.newCall(Request.Builder().url(url).build()).execute().close()
+
+        val rid1 = server.takeRequest().getHeader("X-Request-ID")
+        val rid2 = server.takeRequest().getHeader("X-Request-ID")
+        assertNotEquals("Each request should receive a distinct X-Request-ID", rid1, rid2)
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/network/ResponseInterceptorTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/ResponseInterceptorTest.kt
@@ -1,0 +1,148 @@
+package cn.gdeiassistant.network
+
+import cn.gdeiassistant.data.SessionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+/**
+ * Tests for the existing [ResponseInterceptor]:
+ * - 2xx responses pass through without throwing.
+ * - 401 responses throw [AppException] with the message from the JSON body and clear tokens.
+ * - Non-2xx responses throw [AppException] with the message from the JSON body.
+ *
+ * All test responses include a JSON `message` field so the interceptor uses the body message
+ * rather than falling back to Android-context-dependent string resources.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResponseInterceptorTest {
+
+    private val server = MockWebServer()
+    private lateinit var sessionManager: SessionManager
+    private lateinit var client: OkHttpClient
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        // Provide a main dispatcher so GlobalEventManager.emit() can dispatch its coroutine
+        // without crashing the test thread.
+        Dispatchers.setMain(testDispatcher)
+        server.start()
+        sessionManager = mock()
+        client = OkHttpClient.Builder()
+            .addInterceptor(ResponseInterceptor(sessionManager))
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        server.shutdown()
+    }
+
+    @Test
+    fun successfulResponsePassesThrough() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"success":true}"""))
+
+        val response = client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute()
+
+        assertEquals(200, response.code)
+        response.close()
+        verify(sessionManager, never()).clearTokens()
+    }
+
+    @Test
+    fun unauthorizedResponseThrowsAppExceptionWithBodyMessage() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"success":false,"message":"登录已过期，请重新登录"}""")
+        )
+
+        var caught: AppException? = null
+        try {
+            client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute()
+        } catch (e: AppException) {
+            caught = e
+        }
+
+        assertNotNull("Expected AppException for 401 response", caught)
+        assertEquals("登录已过期，请重新登录", caught!!.message)
+        assertEquals(NetworkConstants.HTTP_UNAUTHORIZED, caught.code)
+    }
+
+    @Test
+    fun unauthorizedResponseClearsTokens() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"success":false,"message":"Token expired"}""")
+        )
+
+        try {
+            client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute()
+        } catch (_: AppException) {
+            // expected
+        }
+
+        verify(sessionManager).clearTokens()
+    }
+
+    @Test
+    fun serverErrorResponseThrowsAppExceptionWithBodyMessage() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"success":false,"message":"内部服务错误"}""")
+        )
+
+        var caught: AppException? = null
+        try {
+            client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute()
+        } catch (e: AppException) {
+            caught = e
+        }
+
+        assertNotNull("Expected AppException for 500 response", caught)
+        assertEquals("内部服务错误", caught!!.message)
+        assertEquals(500, caught.code)
+    }
+
+    @Test
+    fun clientErrorResponseThrowsAppExceptionWithBodyMessage() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(422)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"success":false,"message":"参数校验失败"}""")
+        )
+
+        var caught: AppException? = null
+        try {
+            client.newCall(Request.Builder().url(server.url("/api/test")).build()).execute()
+        } catch (e: AppException) {
+            caught = e
+        }
+
+        assertNotNull("Expected AppException for 422 response", caught)
+        assertEquals("参数校验失败", caught!!.message)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }


### PR DESCRIPTION
## Summary
- Add `RequestIdInterceptor` — generates UUID `X-Request-ID` per outbound request
- Add `NetworkLoggingInterceptor` — structured logging with method, path, status, elapsed time, request id; logs real HTTP status for 4xx/5xx via `AppException.code`
- Wire both interceptors in `NetworkModule` with documented chain order
- Add MockWebServer-backed tests: RequestIdInterceptor (4), ResponseInterceptor (5), NetworkLoggingInterceptor (4)
- Add AuthRepositoryContractTest (4), MarketplaceSearchTest repository-level assertions (4)
- Add `android-ci.yml` GitHub Actions workflow

## Client impact
- All outbound requests now carry `X-Request-ID` for correlation with backend logs

## Test plan
- [ ] `./gradlew testDebugUnitTest` — 88 tests, 0 failures
- [ ] Verify `X-Request-ID` visible in Android logcat output

🤖 Generated with [Claude Code](https://claude.com/claude-code)