### PR TITLE
security: harden WebView and fix cookie domain matching

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/charge/ChargeScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/charge/ChargeScreen.kt
@@ -555,7 +555,7 @@ private fun PaymentPage(
                             val domain = cookie.domain.orEmpty()
                             if (domain.isNotBlank() && allowedCookieDomains.any { allowed ->
                                     domain.equals(allowed, ignoreCase = true)
-                                            || domain.endsWith(allowed, ignoreCase = true)
+                                            || (allowed.startsWith(".") && (domain.equals(allowed.removePrefix("."), ignoreCase = true) || domain.endsWith(allowed, ignoreCase = true)))
                                 }) {
                                 val cookieString = buildString {
                                     append(cookie.name.orEmpty())
@@ -571,6 +571,9 @@ private fun PaymentPage(
 
                         settings.javaScriptEnabled = true
                         settings.domStorageEnabled = true
+                        settings.mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_NEVER_ALLOW
+                        settings.allowFileAccess = false
+                        settings.allowContentAccess = false
                         settings.loadsImagesAutomatically = true
                         settings.loadWithOverviewMode = true
                         settings.useWideViewPort = true


### PR DESCRIPTION
## Summary
- Add MIXED_CONTENT_NEVER_ALLOW to payment WebView
- Disable file/content access in WebView
- Fix cookie domain whitelist suffix matching to prevent confusion attacks

## Test plan
- [ ] Verify Alipay payment page still loads correctly
- [ ] Verify cookies from non-whitelisted domains are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)