### PR TITLE
[codex] align Android palette and normalize API base URLs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
-val devBaseUrl = providers.gradleProperty("GDEI_BASE_URL_DEV").orNull ?: "http://10.0.2.2:8080/api/"
+val devBaseUrl = providers.gradleProperty("GDEI_BASE_URL_DEV").orNull ?: "http://10.0.2.2:8080/"
 val stagingBaseUrl = providers.gradleProperty("GDEI_BASE_URL_STAGING").orNull
-    ?: "https://gdeiassistant.azurewebsites.net/api/"
+    ?: "https://gdeiassistant.azurewebsites.net/"
 val prodBaseUrl = providers.gradleProperty("GDEI_BASE_URL_PROD").orNull
-    ?: "https://gdeiassistant.azurewebsites.net/api/"
+    ?: "https://gdeiassistant.azurewebsites.net/"
 
 android {
     namespace = "cn.gdeiassistant"

--- a/app/src/main/java/cn/gdeiassistant/network/NetworkEnvironment.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/NetworkEnvironment.kt
@@ -4,22 +4,36 @@ import cn.gdeiassistant.BuildConfig
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
+internal fun normalizeApiBaseUrl(rawBaseUrl: String): String {
+    val trimmed = rawBaseUrl.trim()
+    val withoutTrailingSlash = trimmed.removeSuffix("/")
+    val rootBaseUrl = if (withoutTrailingSlash.endsWith("/api", ignoreCase = true)) {
+        withoutTrailingSlash.removeSuffix("/api")
+    } else {
+        withoutTrailingSlash
+    }
+
+    return "$rootBaseUrl/"
+}
+
 enum class NetworkEnvironment(
     val storageValue: String,
-    val baseUrl: String
+    rawBaseUrl: String
 ) {
     DEV(
         storageValue = "dev",
-        baseUrl = BuildConfig.BASE_URL_DEV
+        rawBaseUrl = BuildConfig.BASE_URL_DEV
     ),
     STAGING(
         storageValue = "staging",
-        baseUrl = BuildConfig.BASE_URL_STAGING
+        rawBaseUrl = BuildConfig.BASE_URL_STAGING
     ),
     PROD(
         storageValue = "prod",
-        baseUrl = BuildConfig.BASE_URL_PROD
+        rawBaseUrl = BuildConfig.BASE_URL_PROD
     );
+
+    val baseUrl: String = normalizeApiBaseUrl(rawBaseUrl)
 
     val httpUrl: HttpUrl
         get() = baseUrl.toHttpUrl()

--- a/app/src/test/java/cn/gdeiassistant/network/NetworkEnvironmentTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/NetworkEnvironmentTest.kt
@@ -19,6 +19,14 @@ class NetworkEnvironmentTest {
     }
 
     @Test
+    fun normalizeApiBaseUrlStripsOptionalApiSuffixAndKeepsTrailingSlash() {
+        assertEquals("https://gdeiassistant.azurewebsites.net/", normalizeApiBaseUrl("https://gdeiassistant.azurewebsites.net"))
+        assertEquals("https://gdeiassistant.azurewebsites.net/", normalizeApiBaseUrl("https://gdeiassistant.azurewebsites.net/"))
+        assertEquals("https://gdeiassistant.azurewebsites.net/", normalizeApiBaseUrl("https://gdeiassistant.azurewebsites.net/api"))
+        assertEquals("https://gdeiassistant.azurewebsites.net/", normalizeApiBaseUrl("https://gdeiassistant.azurewebsites.net/api/"))
+    }
+
+    @Test
     fun defaultBaseUrlsResolveApiRoutesWithoutDuplicatingApiPrefix() {
         NetworkEnvironment.entries.forEach { environment ->
             val resolved = environment.httpUrl.resolve("api/auth/login")

--- a/app/src/test/java/cn/gdeiassistant/network/NetworkEnvironmentTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/NetworkEnvironmentTest.kt
@@ -1,6 +1,7 @@
 package cn.gdeiassistant.network
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class NetworkEnvironmentTest {
@@ -15,5 +16,14 @@ class NetworkEnvironmentTest {
         assertEquals(NetworkEnvironment.DEV, NetworkEnvironment.fromStorage(" dev "))
         assertEquals(NetworkEnvironment.STAGING, NetworkEnvironment.fromStorage("STAGING"))
         assertEquals(NetworkEnvironment.PROD, NetworkEnvironment.fromStorage("unknown"))
+    }
+
+    @Test
+    fun defaultBaseUrlsResolveApiRoutesWithoutDuplicatingApiPrefix() {
+        NetworkEnvironment.entries.forEach { environment ->
+            val resolved = environment.httpUrl.resolve("api/auth/login")
+            assertNotNull(resolved)
+            assertEquals("/api/auth/login", resolved?.encodedPath)
+        }
     }
 }


### PR DESCRIPTION
## What changed
- update the fallback campus green palette to the current Material 3 values used by the Android theme
- normalize Android environment base URLs so both root URLs and legacy `/api`-suffixed overrides resolve Retrofit `api/...` routes correctly
- add regression coverage for both normalized base URL strings and resolved API paths

## Why
- keep the Android fallback theme aligned with the latest design tokens
- avoid runtime requests accidentally becoming `/api/api/...` when an environment override already includes `/api`

## Impact
- fallback primary surfaces use the newer Material 3 green values
- Android API routing now tolerates either root URLs or legacy `/api`-suffixed overrides

## Validation
- ./gradlew --no-daemon testDebugUnitTest
- ./gradlew --no-daemon testDebugUnitTest --tests cn.gdeiassistant.network.NetworkEnvironmentTest -PGDEI_BASE_URL_DEV=http://10.0.2.2:8080/api/ -PGDEI_BASE_URL_STAGING=https://gdeiassistant.azurewebsites.net/api/ -PGDEI_BASE_URL_PROD=https://gdeiassistant.azurewebsites.net/api/
