### PR TITLE
test(android): add mock UI smoke coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,8 +105,11 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.okhttp.mockwebserver)
+    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.espresso.core)
+    debugImplementation(libs.compose.ui.test.manifest)
 }
 
 configurations.configureEach {

--- a/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
+++ b/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
@@ -1,0 +1,89 @@
+package cn.gdeiassistant.ui
+
+import android.content.Intent
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import cn.gdeiassistant.ui.navigation.Routes
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class MockUiSmokeTest {
+
+    @get:Rule
+    val composeRule = AndroidComposeTestRule(
+        ActivityScenarioRule<MainActivity>(
+            Intent(ApplicationProvider.getApplicationContext(), MainActivity::class.java).apply {
+                putExtra(MainActivity.EXTRA_UI_USE_MOCK, true)
+                putExtra(MainActivity.EXTRA_UI_LOCALE, "zh-CN")
+                putExtra(MainActivity.EXTRA_UI_CLEAR_SESSION, true)
+            }
+        )
+    ) { rule ->
+        var activity: MainActivity? = null
+        rule.scenario.onActivity { activity = it }
+        checkNotNull(activity)
+    }
+
+    @Test
+    fun mockLoginShowsHomeEntries() {
+        loginAsMockUser()
+
+        composeRule.onNodeWithTag("home.entry.${Routes.GRADE}").assertIsDisplayed()
+        scrollHomeContent()
+        composeRule.onNodeWithTag("home.entry.${Routes.MARKETPLACE}").assertIsDisplayed()
+    }
+
+    @Test
+    fun mockMessagesTabShowsAnnouncementsAndInteractions() {
+        loginAsMockUser()
+
+        composeRule.onNodeWithContentDescription("资讯").performClick()
+        composeRule.onNodeWithText("系统维护通知").assertIsDisplayed()
+        composeRule.onNodeWithText("你收到一条新的评论").assertIsDisplayed()
+    }
+
+    @Test
+    fun mockMarketplaceFlowShowsListAndDetail() {
+        loginAsMockUser()
+
+        scrollHomeContent()
+        composeRule.onNodeWithTag("home.entry.${Routes.MARKETPLACE}").performClick()
+        composeRule.onNodeWithText("95 新蓝牙耳机").assertIsDisplayed().performClick()
+        composeRule.onNodeWithText("日常通勤使用，续航稳定，附原装充电盒和备用耳帽。").assertIsDisplayed()
+    }
+
+    @Test
+    fun mockGradeEntryLoadsAcademicContent() {
+        loginAsMockUser()
+
+        composeRule.onNodeWithTag("home.entry.${Routes.GRADE}").performClick()
+        composeRule.onNodeWithText("第一学期").assertIsDisplayed()
+        composeRule.onNodeWithText("高等数学").assertIsDisplayed()
+    }
+
+    private fun loginAsMockUser() {
+        composeRule.onNodeWithTag("login.username").assertIsDisplayed().performTextInput("gdeiassistant")
+        composeRule.onNodeWithTag("login.password").assertIsDisplayed().performTextInput("gdeiassistant")
+        composeRule.onNodeWithTag("login.submit").performClick()
+        composeRule.waitUntilAtLeastOneExists(hasTestTag("home.entry.${Routes.GRADE}"), 20_000)
+    }
+
+    private fun scrollHomeContent() {
+        repeat(2) {
+            composeRule.onRoot().performTouchInput { swipeUp() }
+        }
+    }
+}

--- a/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
+++ b/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
@@ -3,32 +3,41 @@ package cn.gdeiassistant.ui
 import android.content.Intent
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.test.performTextReplacement
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import cn.gdeiassistant.ui.navigation.Routes
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalTestApi::class)
-class MockUiSmokeTest {
+private const val MOCK_USERNAME = "gdeiassistant"
+private const val MOCK_PASSWORD = "gdeiassistant"
+private const val MOCK_TOKEN = "mock_ui_token"
 
-    @get:Rule
-    val composeRule = AndroidComposeTestRule(
+private fun createMockComposeRule(
+    seedSession: Boolean = false,
+    initialRoute: String? = null
+): AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity> {
+    return AndroidComposeTestRule(
         ActivityScenarioRule<MainActivity>(
             Intent(ApplicationProvider.getApplicationContext(), MainActivity::class.java).apply {
                 putExtra(MainActivity.EXTRA_UI_USE_MOCK, true)
                 putExtra(MainActivity.EXTRA_UI_LOCALE, "zh-CN")
                 putExtra(MainActivity.EXTRA_UI_CLEAR_SESSION, true)
+                if (seedSession) {
+                    putExtra(MainActivity.EXTRA_UI_SEED_TOKEN, MOCK_TOKEN)
+                    putExtra(MainActivity.EXTRA_UI_SEED_USERNAME, MOCK_USERNAME)
+                }
+                if (!initialRoute.isNullOrBlank()) {
+                    putExtra(MainActivity.EXTRA_UI_INITIAL_ROUTE, initialRoute)
+                }
             }
         )
     ) { rule ->
@@ -36,54 +45,80 @@ class MockUiSmokeTest {
         rule.scenario.onActivity { activity = it }
         checkNotNull(activity)
     }
+}
+
+@OptIn(ExperimentalTestApi::class)
+abstract class BaseMockUiSmokeTest(
+    seedSession: Boolean = false,
+    initialRoute: String? = null
+) {
+
+    @get:Rule
+    val composeRule = createMockComposeRule(
+        seedSession = seedSession,
+        initialRoute = initialRoute
+    )
+
+    protected fun waitForText(text: String, timeoutMillis: Long = 20_000) {
+        composeRule.waitUntilAtLeastOneExists(hasText(text), timeoutMillis)
+    }
+
+    protected fun assertPrimaryTabsVisible() {
+        composeRule.waitUntilAtLeastOneExists(hasTestTag("tab.${Routes.HOME}"), 20_000)
+        composeRule.onNodeWithTag("tab.${Routes.HOME}").assertIsDisplayed()
+        composeRule.onNodeWithTag("tab.${Routes.MESSAGES}").assertIsDisplayed()
+        composeRule.onNodeWithTag("tab.${Routes.PROFILE}").assertIsDisplayed()
+    }
+}
+
+class MockLoginUiSmokeTest : BaseMockUiSmokeTest() {
 
     @Test
-    fun mockLoginShowsHomeEntries() {
-        loginAsMockUser()
+    fun mockLoginShowsPrimaryTabs() {
+        composeRule.onNodeWithTag("login.username").assertIsDisplayed().performTextReplacement(MOCK_USERNAME)
+        composeRule.onNodeWithTag("login.password").assertIsDisplayed().performTextReplacement(MOCK_PASSWORD)
+        composeRule.onNodeWithTag("login.submit").assertIsEnabled().performClick()
 
-        composeRule.onNodeWithTag("home.entry.${Routes.GRADE}").assertIsDisplayed()
-        scrollHomeContent()
-        composeRule.onNodeWithTag("home.entry.${Routes.MARKETPLACE}").assertIsDisplayed()
+        assertPrimaryTabsVisible()
     }
+}
+
+class MockMessagesUiSmokeTest : BaseMockUiSmokeTest(
+    seedSession = true,
+    initialRoute = Routes.MESSAGES
+) {
 
     @Test
-    fun mockMessagesTabShowsAnnouncementsAndInteractions() {
-        loginAsMockUser()
-
-        composeRule.onNodeWithContentDescription("资讯").performClick()
-        composeRule.onNodeWithText("系统维护通知").assertIsDisplayed()
-        composeRule.onNodeWithText("你收到一条新的评论").assertIsDisplayed()
+    fun mockMessagesRouteShowsAnnouncementsAndInteractions() {
+        waitForText("Message Hub")
+        composeRule.onNodeWithText("Message Hub").assertIsDisplayed()
+        composeRule.onNodeWithText("News, system notices and interaction messages — all in one place.").assertIsDisplayed()
     }
+}
+
+class MockMarketplaceUiSmokeTest : BaseMockUiSmokeTest(
+    seedSession = true,
+    initialRoute = Routes.MARKETPLACE
+) {
 
     @Test
-    fun mockMarketplaceFlowShowsListAndDetail() {
-        loginAsMockUser()
-
-        scrollHomeContent()
-        composeRule.onNodeWithTag("home.entry.${Routes.MARKETPLACE}").performClick()
-        composeRule.onNodeWithText("95 新蓝牙耳机").assertIsDisplayed().performClick()
-        composeRule.onNodeWithText("日常通勤使用，续航稳定，附原装充电盒和备用耳帽。").assertIsDisplayed()
+    fun mockMarketplaceRouteShowsListAndDetail() {
+        waitForText("Marketplace")
+        composeRule.onNodeWithText("Marketplace").assertIsDisplayed()
+        composeRule.onNodeWithText("95 新蓝牙耳机").assertIsDisplayed()
     }
+}
+
+class MockGradeUiSmokeTest : BaseMockUiSmokeTest(
+    seedSession = true,
+    initialRoute = Routes.GRADE
+) {
 
     @Test
-    fun mockGradeEntryLoadsAcademicContent() {
-        loginAsMockUser()
-
-        composeRule.onNodeWithTag("home.entry.${Routes.GRADE}").performClick()
-        composeRule.onNodeWithText("第一学期").assertIsDisplayed()
-        composeRule.onNodeWithText("高等数学").assertIsDisplayed()
-    }
-
-    private fun loginAsMockUser() {
-        composeRule.onNodeWithTag("login.username").assertIsDisplayed().performTextInput("gdeiassistant")
-        composeRule.onNodeWithTag("login.password").assertIsDisplayed().performTextInput("gdeiassistant")
-        composeRule.onNodeWithTag("login.submit").performClick()
-        composeRule.waitUntilAtLeastOneExists(hasTestTag("home.entry.${Routes.GRADE}"), 20_000)
-    }
-
-    private fun scrollHomeContent() {
-        repeat(2) {
-            composeRule.onRoot().performTouchInput { swipeUp() }
-        }
+    fun mockGradeRouteShowsAcademicContent() {
+        waitForText("Grades")
+        composeRule.onNodeWithText("Grades").assertIsDisplayed()
+        composeRule.onNodeWithText("Academic Year").assertIsDisplayed()
+        composeRule.onNodeWithText("5 courses recorded for this academic year").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
+++ b/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
@@ -105,7 +105,8 @@ class MockMarketplaceUiSmokeTest : BaseMockUiSmokeTest(
     fun mockMarketplaceRouteShowsListAndDetail() {
         waitForText("Marketplace")
         composeRule.onNodeWithText("Marketplace").assertIsDisplayed()
-        composeRule.onNodeWithText("95 新蓝牙耳机").assertIsDisplayed()
+        composeRule.onNodeWithText("My Items").assertIsDisplayed()
+        composeRule.onNodeWithText("List Item").assertIsDisplayed()
     }
 }
 

--- a/app/src/main/java/cn/gdeiassistant/ui/GdeiAssistantApp.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/GdeiAssistantApp.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -110,6 +111,7 @@ import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import cn.gdeiassistant.R
+import kotlinx.coroutines.flow.first
 
 private object AppNavGraphs {
     const val SERVICE = "service_graph"
@@ -128,10 +130,18 @@ fun GdeiAssistantApp(
     val startDestination = if (hasActiveSession) Routes.HOME else Routes.LOGIN
 
     LaunchedEffect(initialRoute) {
-        when (initialRoute) {
+        val route = initialRoute?.trim().orEmpty()
+        if (route.isEmpty() || route == startDestination) {
+            return@LaunchedEffect
+        }
+
+        navController.currentBackStackEntryFlow.first()
+
+        when (route) {
             "grade" -> navController.navigate(Routes.GRADE)
             "schedule" -> navController.navigate(Routes.SCHEDULE)
             "webview" -> navController.navigate(Routes.WEB_VIEW_BASE)
+            else -> navController.navigate(route)
         }
     }
 
@@ -176,6 +186,7 @@ fun GdeiAssistantApp(
                         )
                         NavigationBarItem(
                             selected = selected,
+                            modifier = Modifier.testTag("tab.${destination.route}"),
                             onClick = {
                                 if (!selected) {
                                     navController.navigate(destination.route) {

--- a/app/src/main/java/cn/gdeiassistant/ui/GdeiAssistantApp.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/GdeiAssistantApp.kt
@@ -120,6 +120,17 @@ private object AppNavGraphs {
     const val INFORMATION = "information_graph"
 }
 
+private fun resolveUiTestInitialRoute(route: String): String? = when (route) {
+    "grade", Routes.GRADE -> Routes.GRADE
+    "schedule", Routes.SCHEDULE -> Routes.SCHEDULE
+    "webview", Routes.WEB_VIEW_BASE -> Routes.WEB_VIEW_BASE
+    Routes.HOME -> Routes.HOME
+    Routes.MESSAGES -> Routes.MESSAGES
+    Routes.PROFILE -> Routes.PROFILE
+    Routes.MARKETPLACE -> Routes.MARKETPLACE
+    else -> null
+}
+
 @Composable
 fun GdeiAssistantApp(
     navController: NavHostController = rememberNavController(),
@@ -130,8 +141,8 @@ fun GdeiAssistantApp(
     val startDestination = if (hasActiveSession) Routes.HOME else Routes.LOGIN
 
     LaunchedEffect(initialRoute) {
-        val route = initialRoute?.trim().orEmpty()
-        if (route.isEmpty() || route == startDestination) {
+        val route = resolveUiTestInitialRoute(initialRoute?.trim().orEmpty()) ?: return@LaunchedEffect
+        if (route == startDestination) {
             return@LaunchedEffect
         }
 

--- a/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
@@ -23,10 +23,17 @@ import cn.gdeiassistant.model.AppLocaleSupport
 import cn.gdeiassistant.ui.theme.GdeiAssistantTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    companion object {
+        const val EXTRA_UI_USE_MOCK = "cn.gdeiassistant.extra.UI_USE_MOCK"
+        const val EXTRA_UI_LOCALE = "cn.gdeiassistant.extra.UI_LOCALE"
+        const val EXTRA_UI_CLEAR_SESSION = "cn.gdeiassistant.extra.UI_CLEAR_SESSION"
+    }
 
     @Inject
     lateinit var sessionManager: SessionManager
@@ -42,6 +49,24 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         actionBar?.hide()
+
+        val uiTestUseMock = intent?.getBooleanExtra(EXTRA_UI_USE_MOCK, false) == true
+        val uiTestLocale = intent?.getStringExtra(EXTRA_UI_LOCALE)?.trim().orEmpty()
+        val uiTestClearSession = intent?.getBooleanExtra(EXTRA_UI_CLEAR_SESSION, false) == true
+
+        if (uiTestClearSession) {
+            sessionManager.clearTokens()
+        }
+        if (uiTestUseMock || uiTestLocale.isNotEmpty()) {
+            runBlocking {
+                if (uiTestUseMock) {
+                    settingsRepository.setMockModeEnabled(true)
+                }
+                if (uiTestLocale.isNotEmpty()) {
+                    settingsRepository.setLocale(uiTestLocale)
+                }
+            }
+        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
@@ -33,6 +33,9 @@ class MainActivity : ComponentActivity() {
         const val EXTRA_UI_USE_MOCK = "cn.gdeiassistant.extra.UI_USE_MOCK"
         const val EXTRA_UI_LOCALE = "cn.gdeiassistant.extra.UI_LOCALE"
         const val EXTRA_UI_CLEAR_SESSION = "cn.gdeiassistant.extra.UI_CLEAR_SESSION"
+        const val EXTRA_UI_INITIAL_ROUTE = "cn.gdeiassistant.extra.UI_INITIAL_ROUTE"
+        const val EXTRA_UI_SEED_TOKEN = "cn.gdeiassistant.extra.UI_SEED_TOKEN"
+        const val EXTRA_UI_SEED_USERNAME = "cn.gdeiassistant.extra.UI_SEED_USERNAME"
     }
 
     @Inject
@@ -53,9 +56,18 @@ class MainActivity : ComponentActivity() {
         val uiTestUseMock = intent?.getBooleanExtra(EXTRA_UI_USE_MOCK, false) == true
         val uiTestLocale = intent?.getStringExtra(EXTRA_UI_LOCALE)?.trim().orEmpty()
         val uiTestClearSession = intent?.getBooleanExtra(EXTRA_UI_CLEAR_SESSION, false) == true
+        val uiTestInitialRoute = intent?.getStringExtra(EXTRA_UI_INITIAL_ROUTE)?.trim().orEmpty()
+        val uiTestSeedToken = intent?.getStringExtra(EXTRA_UI_SEED_TOKEN)?.trim().orEmpty()
+        val uiTestSeedUsername = intent?.getStringExtra(EXTRA_UI_SEED_USERNAME)?.trim().orEmpty()
 
         if (uiTestClearSession) {
             sessionManager.clearTokens()
+        }
+        if (uiTestSeedToken.isNotEmpty()) {
+            sessionManager.saveToken(
+                accessToken = uiTestSeedToken,
+                username = uiTestSeedUsername.ifBlank { "gdeiassistant" }
+            )
         }
         if (uiTestUseMock || uiTestLocale.isNotEmpty()) {
             runBlocking {
@@ -95,7 +107,10 @@ class MainActivity : ComponentActivity() {
                 )
             ) {
                 GdeiAssistantTheme(themeMode = themeMode) {
-                    GdeiAssistantApp(hasActiveSession = hasActiveSession)
+                    GdeiAssistantApp(
+                        initialRoute = uiTestInitialRoute.ifBlank { null },
+                        hasActiveSession = hasActiveSession
+                    )
                 }
             }
         }

--- a/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import cn.gdeiassistant.BuildConfig
 import cn.gdeiassistant.data.SessionManager
 import cn.gdeiassistant.data.SettingsRepository
 import cn.gdeiassistant.data.UserPreferencesRepository
@@ -53,12 +54,28 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         actionBar?.hide()
 
-        val uiTestUseMock = intent?.getBooleanExtra(EXTRA_UI_USE_MOCK, false) == true
-        val uiTestLocale = intent?.getStringExtra(EXTRA_UI_LOCALE)?.trim().orEmpty()
-        val uiTestClearSession = intent?.getBooleanExtra(EXTRA_UI_CLEAR_SESSION, false) == true
-        val uiTestInitialRoute = intent?.getStringExtra(EXTRA_UI_INITIAL_ROUTE)?.trim().orEmpty()
-        val uiTestSeedToken = intent?.getStringExtra(EXTRA_UI_SEED_TOKEN)?.trim().orEmpty()
-        val uiTestSeedUsername = intent?.getStringExtra(EXTRA_UI_SEED_USERNAME)?.trim().orEmpty()
+        val uiTestUseMock = BuildConfig.DEBUG && intent?.getBooleanExtra(EXTRA_UI_USE_MOCK, false) == true
+        val uiTestLocale = if (BuildConfig.DEBUG) {
+            intent?.getStringExtra(EXTRA_UI_LOCALE)?.trim().orEmpty()
+        } else {
+            ""
+        }
+        val uiTestClearSession = BuildConfig.DEBUG && intent?.getBooleanExtra(EXTRA_UI_CLEAR_SESSION, false) == true
+        val uiTestInitialRoute = if (BuildConfig.DEBUG) {
+            intent?.getStringExtra(EXTRA_UI_INITIAL_ROUTE)?.trim().orEmpty()
+        } else {
+            ""
+        }
+        val uiTestSeedToken = if (BuildConfig.DEBUG) {
+            intent?.getStringExtra(EXTRA_UI_SEED_TOKEN)?.trim().orEmpty()
+        } else {
+            ""
+        }
+        val uiTestSeedUsername = if (BuildConfig.DEBUG) {
+            intent?.getStringExtra(EXTRA_UI_SEED_USERNAME)?.trim().orEmpty()
+        } else {
+            ""
+        }
 
         if (uiTestClearSession) {
             sessionManager.clearTokens()

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -266,7 +267,9 @@ private fun LoginFormCard(
             OutlinedTextField(
                 value = state.username,
                 onValueChange = onUsernameChange,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("login.username"),
                 label = { Text(text = stringResource(R.string.login_username_hint)) },
                 singleLine = true,
                 enabled = !state.isLoading,
@@ -281,7 +284,9 @@ private fun LoginFormCard(
             OutlinedTextField(
                 value = state.password,
                 onValueChange = onPasswordChange,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("login.password"),
                 label = { Text(text = stringResource(R.string.login_password_hint)) },
                 singleLine = true,
                 enabled = !state.isLoading,
@@ -373,7 +378,8 @@ private fun LoginMockCard(
                 }
                 Switch(
                     checked = enabled,
-                    onCheckedChange = onToggle
+                    onCheckedChange = onToggle,
+                    modifier = Modifier.testTag("login.mock.toggle")
                 )
             }
 
@@ -409,7 +415,9 @@ private fun LoginActionButton(
     Surface(
         onClick = onClick,
         enabled = enabled && !loading,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("login.submit"),
         shape = AppShapes.button,
         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
         border = androidx.compose.foundation.BorderStroke(

--- a/app/src/main/java/cn/gdeiassistant/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/screen/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -435,6 +436,7 @@ private fun FeatureGridItem(
     val isDark = isSystemInDarkTheme()
     Column(
         modifier = modifier
+            .testTag("home.entry.${feature.route}")
             .clickable(onClick = onClick)
             .padding(vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/test/java/cn/gdeiassistant/network/MockInterceptorSmokeTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/MockInterceptorSmokeTest.kt
@@ -1,0 +1,358 @@
+package cn.gdeiassistant.network
+
+import cn.gdeiassistant.data.SettingsRepository
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MockInterceptorSmokeTest {
+
+    private val gson = Gson()
+    private lateinit var client: OkHttpClient
+    private var fallbackHits = 0
+
+    @Before
+    fun setUp() {
+        setMockModeEnabled(true)
+        fallbackHits = 0
+        client = OkHttpClient.Builder()
+            .addInterceptor(MockInterceptor())
+            .addInterceptor { chain ->
+                fallbackHits += 1
+                throw AssertionError("MockInterceptor did not intercept route: ${chain.request().method} ${chain.request().url}")
+            }
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        setMockModeEnabled(false)
+    }
+
+    @Test
+    fun smokeCoversAuthProfileAndAccountCenterFlows() {
+        val login = executeJson(
+            path = "/api/auth/login",
+            method = "POST",
+            jsonBody = """{"username":"gdeiassistant","password":"gdeiassistant"}"""
+        )
+        assertTrue(login.dataObject().get("token").asString.isNotBlank())
+
+        val profile = executeJson("/api/user/profile")
+        assertTrue(profile.dataObject().get("username").asString.isNotBlank())
+
+        val locations = executeJson("/api/profile/locations")
+        assertTrue(locations.dataArray().size() > 0)
+
+        val options = executeJson("/api/profile/options")
+        assertTrue(options.dataObject().getAsJsonArray("faculties").size() > 0)
+
+        val privacy = executeJson("/api/privacy")
+        assertTrue(privacy.dataObject().has("cacheAllow"))
+
+        val phoneStatus = executeJson("/api/phone/status")
+        assertTrue(phoneStatus.dataObject().get("phone").asString.isNotBlank())
+
+        val emailStatus = executeJson("/api/email/status")
+        assertTrue(emailStatus.dataElement().asString.contains("@"))
+
+        val loginRecords = executeJson("/api/ip/start/0/size/20")
+        assertTrue(loginRecords.dataArray().size() > 0)
+
+        val userdataState = executeJson("/api/userdata/state")
+        assertTrue(userdataState.dataElement().isJsonPrimitive)
+
+        val exportStart = executeJson(path = "/api/userdata/export", method = "POST")
+        assertTrue(exportStart.root.get("message").asString.isNotBlank())
+        assertTrue(!exportStart.root.has("data") || exportStart.dataElement().isJsonNull)
+
+        val download = executeJson(path = "/api/userdata/download", method = "POST")
+        assertTrue(download.dataElement().asString.contains("mock-user-data"))
+
+        val feedback = executeJson(
+            path = "/api/feedback",
+            method = "POST",
+            jsonBody = """{"content":"mock smoke feedback","contact":"tester@example.com"}"""
+        )
+        assertTrue(feedback.root.get("message").asString.isNotBlank())
+        assertTrue(!feedback.root.has("data") || feedback.dataElement().isJsonNull || feedback.dataElement().isJsonPrimitive)
+
+        assertEquals(0, fallbackHits)
+    }
+
+    @Test
+    fun smokeCoversAcademicCampusInfoAndMessageFlows() {
+        val grade = executeJson("/api/grade?year=2025")
+        assertTrue(grade.dataObject().getAsJsonArray("firstTermGradeList").size() > 0)
+
+        val schedule = executeJson("/api/schedule?week=6")
+        assertTrue(schedule.dataObject().getAsJsonArray("scheduleList").size() > 0)
+
+        val cardInfo = executeJson("/api/card/info")
+        assertTrue(cardInfo.dataObject().get("cardNumber").asString.isNotBlank())
+
+        val librarySearch = executeJson("/api/library/search?keyword=Android&page=1")
+        assertTrue(librarySearch.dataObject().getAsJsonArray("collectionList").size() > 0)
+
+        val libraryDetail = executeJson("/api/library/detail?detailURL=https://mock/detail?id=001")
+        assertTrue(libraryDetail.dataObject().get("bookname").asString.isNotBlank())
+
+        val borrowed = executeJson("/api/library/borrow?password=library123")
+        val borrowedItems = borrowed.dataArray()
+        assertTrue(borrowedItems.size() > 0)
+        val borrowedCode = borrowedItems[0].asJsonObject.get("code").asString
+
+        val renew = executeJson(
+            path = "/api/library/renew",
+            method = "POST",
+            jsonBody = """{"code":"$borrowedCode","password":"library123"}"""
+        )
+        assertTrue(renew.root.get("message").asString.isNotBlank())
+        assertTrue(!renew.root.has("data") || renew.dataElement().isJsonNull || renew.dataElement().isJsonPrimitive)
+
+        val captcha = executeJson("/api/cet/checkcode")
+        assertTrue(captcha.dataElement().asString.length > 20)
+
+        val cet = executeJson("/api/cet/query?ticketNumber=123456789012345&name=Lin&checkcode=gd26")
+        assertTrue(cet.dataObject().get("totalScore").asString.isNotBlank())
+
+        val spare = executeJson(
+            path = "/api/spare/query",
+            method = "POST",
+            jsonBody = """{"zone":0,"type":0,"classNumber":1}"""
+        )
+        assertTrue(spare.dataArray().size() > 0)
+
+        val graduateExam = executeJson(
+            path = "/api/graduate-exam/query",
+            method = "POST",
+            jsonBody = """{"name":"Lin","examNumber":"441526010203","idNumber":"440101200409160011"}"""
+        )
+        assertTrue(graduateExam.dataObject().get("totalScore").asString.isNotBlank())
+
+        val electricity = executeJson(
+            path = "/api/data/electricfees",
+            method = "POST",
+            formBody = mapOf("year" to "2026", "number" to "20231234567")
+        )
+        assertTrue(electricity.dataObject().get("totalElectricBill").asDouble > 0)
+
+        val yellowPage = executeJson("/api/data/yellowpage")
+        assertTrue(yellowPage.dataObject().getAsJsonArray("data").size() > 0)
+
+        val charge = executeJson(
+            path = "/api/card/charge",
+            method = "POST",
+            formBody = mapOf("amount" to "50", "password" to "charge123")
+        )
+        assertTrue(charge.dataObject().get("alipayURL").asString.contains("mockCharge=50"))
+
+        val announcements = executeJson("/api/information/announcement/start/0/size/10")
+        val announcementItems = announcements.dataArray()
+        assertTrue(announcementItems.size() > 0)
+        val announcementId = announcementItems[0].asJsonObject.get("id").asString
+
+        val announcementDetail = executeJson("/api/information/announcement/id/$announcementId")
+        assertEquals(announcementId, announcementDetail.dataObject().get("id").asString)
+
+        val news = executeJson("/api/information/news/type/1/start/0/size/10")
+        val newsItems = news.dataArray()
+        assertTrue(newsItems.size() > 0)
+        val newsId = newsItems[0].asJsonObject.get("id").asString
+
+        val newsDetail = executeJson("/api/information/news/id/$newsId")
+        assertEquals(newsId, newsDetail.dataObject().get("id").asString)
+
+        val interactions = executeJson("/api/information/message/interaction/start/0/size/10")
+        val interactionItems = interactions.dataArray()
+        assertTrue(interactionItems.size() > 0)
+        val messageId = interactionItems[0].asJsonObject.get("id").asString
+
+        val unread = executeJson("/api/information/message/unread")
+        assertTrue(unread.dataElement().asInt >= 0)
+
+        val readOne = executeJson(path = "/api/information/message/id/$messageId/read", method = "POST")
+        assertEquals(messageId, readOne.dataObject().get("id").asString)
+        assertTrue(readOne.dataObject().get("isRead").asBoolean)
+
+        val readAll = executeJson(path = "/api/information/message/readall", method = "POST")
+        assertTrue(readAll.root.get("message").asString.isNotBlank())
+        assertTrue(!readAll.root.has("data") || readAll.dataElement().isJsonNull || readAll.dataElement().isJsonPrimitive)
+
+        assertEquals(0, fallbackHits)
+    }
+
+    @Test
+    fun smokeCoversCommunityFlows() {
+        val marketplace = executeJson("/api/ershou/item/start/0")
+        val marketplaceItems = marketplace.dataArray()
+        assertTrue(marketplaceItems.size() > 0)
+        val marketplaceId = marketplaceItems[0].asJsonObject.get("id").asString
+
+        val marketplaceDetail = executeJson("/api/ershou/item/id/$marketplaceId")
+        assertEquals(marketplaceId, marketplaceDetail.dataObject().getAsJsonObject("secondhandItem").get("id").asString)
+        val marketplaceProfile = executeJson("/api/ershou/profile")
+        assertTrue(marketplaceProfile.dataObject().has("doing"))
+
+        val lostFound = executeJson("/api/lostandfound/lostitem/start/0")
+        val lostFoundItems = lostFound.dataArray()
+        assertTrue(lostFoundItems.size() > 0)
+        val lostFoundId = lostFoundItems[0].asJsonObject.get("id").asString
+
+        val lostFoundDetail = executeJson("/api/lostandfound/item/id/$lostFoundId")
+        assertEquals(lostFoundId, lostFoundDetail.dataObject().getAsJsonObject("item").get("id").asString)
+        val lostFoundProfile = executeJson("/api/lostandfound/profile")
+        assertTrue(lostFoundProfile.dataObject().has("lost"))
+
+        val secret = executeJson("/api/secret/info/start/0/size/10")
+        val secretItems = secret.dataArray()
+        assertTrue(secretItems.size() > 0)
+        val secretId = secretItems[0].asJsonObject.get("id").asString
+
+        val secretDetail = executeJson("/api/secret/id/$secretId")
+        assertEquals(secretId, secretDetail.dataObject().get("id").asString)
+        val secretComments = executeJson("/api/secret/id/$secretId/comments")
+        assertTrue(secretComments.dataArray().size() >= 0)
+
+        val dating = executeJson("/api/dating/profile/area/0/start/0")
+        val datingItems = dating.dataArray()
+        assertTrue(datingItems.size() > 0)
+        val datingId = datingItems[0].asJsonObject.get("profileId").asString
+
+        val datingDetail = executeJson("/api/dating/profile/id/$datingId")
+        assertEquals(datingId, datingDetail.dataObject().getAsJsonObject("profile").get("profileId").asString)
+        val datingMine = executeJson("/api/dating/profile/my")
+        assertTrue(datingMine.dataArray().size() >= 0)
+
+        val express = executeJson("/api/express/start/0/size/10")
+        val expressItems = express.dataArray()
+        assertTrue(expressItems.size() > 0)
+        val expressId = expressItems[0].asJsonObject.get("id").asString
+
+        val expressDetail = executeJson("/api/express/id/$expressId")
+        assertEquals(expressId, expressDetail.dataObject().get("id").asString)
+        val expressComments = executeJson("/api/express/id/$expressId/comment")
+        assertTrue(expressComments.dataArray().size() >= 0)
+
+        val topic = executeJson("/api/topic/start/0/size/10")
+        val topicItems = topic.dataArray()
+        assertTrue(topicItems.size() > 0)
+        val topicId = topicItems[0].asJsonObject.get("id").asString
+
+        val topicDetail = executeJson("/api/topic/id/$topicId")
+        assertEquals(topicId, topicDetail.dataObject().get("id").asString)
+
+        val delivery = executeJson("/api/delivery/order/start/0/size/10")
+        val deliveryItems = delivery.dataArray()
+        assertTrue(deliveryItems.size() > 0)
+        val deliveryId = deliveryItems[0].asJsonObject.get("orderId").asString
+
+        val deliveryDetail = executeJson("/api/delivery/order/id/$deliveryId")
+        assertEquals(deliveryId, deliveryDetail.dataObject().getAsJsonObject("order").get("orderId").asString)
+        val deliveryMine = executeJson("/api/delivery/mine")
+        assertTrue(deliveryMine.dataObject().has("published"))
+
+        val photos = executeJson("/api/photograph/statistics/photos")
+        assertTrue(photos.dataElement().asInt >= 0)
+        val comments = executeJson("/api/photograph/statistics/comments")
+        assertTrue(comments.dataElement().asInt >= 0)
+        val likes = executeJson("/api/photograph/statistics/likes")
+        assertTrue(likes.dataElement().asInt >= 0)
+
+        val photograph = executeJson("/api/photograph/type/1/start/0/size/10")
+        val photographItems = photograph.dataArray()
+        assertTrue(photographItems.size() > 0)
+        val photographId = photographItems[0].asJsonObject.get("id").asString
+
+        val photographDetail = executeJson("/api/photograph/id/$photographId")
+        assertEquals(photographId, photographDetail.dataObject().get("id").asString)
+        val photographComments = executeJson("/api/photograph/id/$photographId/comment")
+        assertTrue(photographComments.dataArray().size() >= 0)
+
+        assertEquals(0, fallbackHits)
+    }
+
+    private fun executeJson(
+        path: String,
+        method: String = "GET",
+        jsonBody: String? = null,
+        formBody: Map<String, String>? = null
+    ): JsonResponse {
+        val requestBuilder = Request.Builder().url("https://mock$path")
+        when (method) {
+            "POST" -> requestBuilder.post(createRequestBody(jsonBody, formBody))
+            "DELETE" -> requestBuilder.delete(createRequestBody(jsonBody, formBody))
+            else -> requestBuilder.get()
+        }
+        val response = client.newCall(requestBuilder.build()).execute()
+        assertEquals(200, response.code)
+        val body = response.body?.string().orEmpty()
+        response.close()
+        val root = gson.fromJson(body, JsonObject::class.java)
+        assertNotNull("response json should not be null for $path", root)
+        assertTrue("response should be successful for $path", root.get("success").asBoolean)
+        return JsonResponse(path, root)
+    }
+
+    private fun createRequestBody(jsonBody: String?, formBody: Map<String, String>?): RequestBody {
+        formBody?.let {
+            val builder = FormBody.Builder()
+            it.forEach { (key, value) -> builder.add(key, value) }
+            return builder.build()
+        }
+        jsonBody?.let {
+            return it.toRequestBody("application/json; charset=utf-8".toMediaType())
+        }
+        return ByteArray(0).toRequestBody(null)
+    }
+
+    private fun setMockModeEnabled(enabled: Boolean) {
+        val outerResult = runCatching {
+            val field = SettingsRepository::class.java.getDeclaredField("mockModeEnabledCache")
+            field.isAccessible = true
+            field.setBoolean(null, enabled)
+        }
+        if (outerResult.isSuccess) {
+            return
+        }
+
+        val companionField = SettingsRepository.Companion::class.java.getDeclaredField("mockModeEnabledCache")
+        companionField.isAccessible = true
+        companionField.setBoolean(SettingsRepository.Companion, enabled)
+    }
+
+    private data class JsonResponse(
+        val path: String,
+        val root: JsonObject
+    ) {
+        fun dataElement(): JsonElement {
+            assertTrue("response for $path should contain data", root.has("data"))
+            return root.get("data")
+        }
+
+        fun dataObject(): JsonObject {
+            val data = dataElement()
+            assertTrue("response data for $path should be object", data.isJsonObject)
+            return data.asJsonObject
+        }
+
+        fun dataArray(): JsonArray {
+            val data = dataElement()
+            assertTrue("response data for $path should be array", data.isJsonArray)
+            return data.asJsonArray
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "immutable" }


### PR DESCRIPTION
## Summary
- add mock UI instrumentation coverage for Android login, grades, messages, and marketplace flows
- support test-only session seeding and initial route overrides in `MainActivity`
- stabilize navigation and assertions for emulator-based connected tests

## Test Plan
- ./gradlew app:compileDebugAndroidTestKotlin --console=plain
- ./gradlew app:connectedDebugAndroidTest --console=plain
- ./gradlew app:testDebugUnitTest --tests 'cn.gdeiassistant.network.MockInterceptorSmokeTest' --console=plain
