### PR TITLE
[codex] Expand Android CI and add session/viewmodel tests

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -41,8 +41,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Run Android lint
+        run: ./gradlew lintDebug
+
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
 
       - name: Upload test reports on failure
         if: failure()
@@ -52,4 +58,6 @@ jobs:
           path: |
             app/build/reports/tests/
             app/build/test-results/
+            app/build/reports/lint-results*
+            app/build/outputs/apk/debug/
           retention-days: 7

--- a/app/src/main/java/cn/gdeiassistant/ui/lostfound/LostFoundScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/lostfound/LostFoundScreen.kt
@@ -431,10 +431,11 @@ fun LostFoundProfileScreen(navController: NavHostController) {
                 }
                 item {
                     AnimatedContent(
-                        targetState = state.selectedTab,
+                        targetState = state.selectedTab to state.visibleItems,
                         label = "lost_found_profile_tab"
-                    ) {
-                        if (state.visibleItems.isEmpty()) {
+                    ) { contentState ->
+                        val visibleItems = contentState.second
+                        if (visibleItems.isEmpty()) {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -448,7 +449,7 @@ fun LostFoundProfileScreen(navController: NavHostController) {
                             }
                         } else {
                             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                state.visibleItems.forEach { item ->
+                                visibleItems.forEach { item ->
                                     LostFoundProfileCard(
                                         item = item,
                                         tab = state.selectedTab,

--- a/app/src/main/java/cn/gdeiassistant/ui/marketplace/MarketplaceScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/marketplace/MarketplaceScreen.kt
@@ -442,10 +442,11 @@ fun MarketplaceProfileScreen(navController: NavHostController) {
                 }
                 item {
                     AnimatedContent(
-                        targetState = state.selectedTab,
+                        targetState = state.selectedTab to state.visibleItems,
                         label = "marketplace_profile_tab"
-                    ) {
-                        if (state.visibleItems.isEmpty()) {
+                    ) { contentState ->
+                        val visibleItems = contentState.second
+                        if (visibleItems.isEmpty()) {
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -459,7 +460,7 @@ fun MarketplaceProfileScreen(navController: NavHostController) {
                             }
                         } else {
                             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                state.visibleItems.forEach { item ->
+                                visibleItems.forEach { item ->
                                     MarketplaceProfileCard(
                                         item = item,
                                         tab = state.selectedTab,

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AvatarEditScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AvatarEditScreen.kt
@@ -90,12 +90,12 @@ fun AvatarEditScreen(navController: NavHostController) {
         item {
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 AnimatedContent(
-                    targetState = state.previewModel?.toString().orEmpty(),
+                    targetState = state.previewModel,
                     transitionSpec = { fadeIn() togetherWith fadeOut() },
                     label = "avatar-preview"
-                ) {
+                ) { previewModel ->
                     ProfileAvatar(
-                        imageModel = state.previewModel,
+                        imageModel = previewModel,
                         fallbackLabel = state.fallbackLabel,
                         size = 132.dp
                     )

--- a/app/src/main/java/cn/gdeiassistant/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/schedule/ScheduleScreen.kt
@@ -426,18 +426,19 @@ private fun TodayAgendaCard(
         )
         Spacer(modifier = Modifier.height(14.dp))
         AnimatedContent(
-            targetState = Triple(isCurrentWeek, selectedWeek, courses.size),
+            targetState = Triple(isCurrentWeek, selectedWeek, courses),
             label = "schedule_focus_courses"
-        ) {
+        ) { contentState ->
+            val currentCourses = contentState.third
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                if (courses.isEmpty()) {
+                if (currentCourses.isEmpty()) {
                     Text(
                         text = if (isCurrentWeek) emptyCurrentText else emptyOtherText,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 } else {
-                    courses.forEach { course ->
+                    currentCourses.forEach { course ->
                         FocusCourseRow(course = course, onClick = { onCourseClick(course) })
                     }
                 }

--- a/app/src/main/java/cn/gdeiassistant/ui/spare/SpareScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/spare/SpareScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -75,7 +75,7 @@ fun SpareScreen(navController: NavHostController) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val query = state.query
     val locale = AppLocaleSupport.normalizeLocale(
-        LocalContext.current.resources.configuration.locales.get(0)?.toLanguageTag()
+        LocalConfiguration.current.locales.get(0)?.toLanguageTag()
     )
     val zoneOptions = remember(locale) { spareZoneOptions(locale) }
     val weekdayOptions = remember(locale) { spareWeekdayOptions(locale) }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1386,6 +1386,7 @@
     <string name="profile_settings_mock_title">ローカルシミュレーションデータ</string>
     <string name="profile_settings_mock_subtitle">有効にすると Mock インターセプタがローカルサンプルデータを優先的に返します</string>
     <string name="profile_settings_environment_title">API環境</string>
+    <string name="profile_language_title">言語</string>
     <string name="profile_settings_environment_subtitle">本番APIは dev / staging / prod の3段階切り替えをサポートし、ローカル連携やグレーリリース検証に便利です</string>
     <string name="profile_settings_environment_release_subtitle">現在はデバッグビルドではないため、現在の環境情報のみ表示しています</string>
     <string name="profile_settings_environment_endpoint_title">現在のサービスアドレス</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1386,6 +1386,7 @@
     <string name="profile_settings_mock_title">로컬 시뮬레이션 데이터</string>
     <string name="profile_settings_mock_subtitle">활성화하면 Mock 인터셉터가 로컬 샘플 데이터를 우선 반환합니다</string>
     <string name="profile_settings_environment_title">API 환경</string>
+    <string name="profile_language_title">언어</string>
     <string name="profile_settings_environment_subtitle">실제 API는 dev / staging / prod 세 단계 전환을 지원하여 로컬 연동 및 회색 검증에 편리합니다</string>
     <string name="profile_settings_environment_release_subtitle">현재 비디버그 빌드이며, 현재 환경 정보만 표시됩니다</string>
     <string name="profile_settings_environment_endpoint_title">현재 서비스 주소</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1385,6 +1385,7 @@
     <string name="profile_settings_mock_title">本地模擬數據</string>
     <string name="profile_settings_mock_subtitle">開啟後優先使用 Mock 攔截器返回本地示例數據</string>
     <string name="profile_settings_environment_title">接口環境</string>
+    <string name="profile_language_title">語言</string>
     <string name="profile_settings_environment_subtitle">真實接口支持 dev / staging / prod 三檔切換，便於本地聯調和灰度驗證</string>
     <string name="profile_settings_environment_release_subtitle">當前為非調試構建，僅展示當前環境信息</string>
     <string name="profile_settings_environment_endpoint_title">當前服務地址</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1385,6 +1385,7 @@
     <string name="profile_settings_mock_title">本機模擬資料</string>
     <string name="profile_settings_mock_subtitle">開啟後優先使用 Mock 攔截器回傳本機範例資料</string>
     <string name="profile_settings_environment_title">介面環境</string>
+    <string name="profile_language_title">語言</string>
     <string name="profile_settings_environment_subtitle">真實介面支援 dev / staging / prod 三檔切換，便於本機聯調和灰度驗證</string>
     <string name="profile_settings_environment_release_subtitle">當前為非偵錯建置，僅展示當前環境訊息</string>
     <string name="profile_settings_environment_endpoint_title">當前服務位址</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:locale="zh">
 
     <string name="app_name">广东二师助手</string>
 

--- a/app/src/test/java/cn/gdeiassistant/data/SessionManagerTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/SessionManagerTest.kt
@@ -1,0 +1,70 @@
+package cn.gdeiassistant.data
+
+import android.content.Context
+import cn.gdeiassistant.util.TokenUtils
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.mock
+
+class SessionManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var tokenUtilsMock: MockedStatic<TokenUtils>
+
+    @Before
+    fun setUp() {
+        context = mock()
+        tokenUtilsMock = mockStatic(TokenUtils::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        tokenUtilsMock.close()
+    }
+
+    @Test
+    fun constructorRestoresCachedTokenAndUsername() {
+        val token = "header.payload.signature"
+        tokenUtilsMock.`when`<String?> { TokenUtils.GetUserAccessToken(context) }.thenReturn(token)
+        tokenUtilsMock.`when`<String?> { TokenUtils.GetAccessTokenUsername(token) }.thenReturn("alice")
+
+        val sessionManager = SessionManager(context)
+
+        assertTrue(sessionManager.hasActiveSession())
+        assertEquals(token, sessionManager.currentToken())
+        assertEquals("alice", sessionManager.currentUsername())
+    }
+
+    @Test
+    fun saveTokenUpdatesInMemorySessionUsingTrimmedUsername() {
+        tokenUtilsMock.`when`<String?> { TokenUtils.GetUserAccessToken(context) }.thenReturn(null)
+
+        val sessionManager = SessionManager(context)
+        sessionManager.saveToken("fresh-token", "  alice  ")
+
+        tokenUtilsMock.verify { TokenUtils.SaveUserToken("fresh-token", context) }
+        assertEquals("fresh-token", sessionManager.currentToken())
+        assertEquals("alice", sessionManager.currentUsername())
+    }
+
+    @Test
+    fun clearTokensClearsCachedSessionState() {
+        val token = "cached-token"
+        tokenUtilsMock.`when`<String?> { TokenUtils.GetUserAccessToken(context) }.thenReturn(token, null)
+        tokenUtilsMock.`when`<String?> { TokenUtils.GetAccessTokenUsername(token) }.thenReturn("alice")
+
+        val sessionManager = SessionManager(context)
+        sessionManager.clearTokens()
+
+        tokenUtilsMock.verify { TokenUtils.ClearUserToken(context) }
+        assertFalse(sessionManager.hasActiveSession())
+        assertEquals(null, sessionManager.currentToken())
+        assertEquals(null, sessionManager.currentUsername())
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/home/HomeViewModelTest.kt
@@ -1,0 +1,117 @@
+package cn.gdeiassistant.ui.home
+
+import cn.gdeiassistant.data.AnnouncementRepository
+import cn.gdeiassistant.data.CardRepository
+import cn.gdeiassistant.data.ProfileRepository
+import cn.gdeiassistant.data.ScheduleRepository
+import cn.gdeiassistant.data.SessionManager
+import cn.gdeiassistant.model.AnnouncementItem
+import cn.gdeiassistant.model.CardInfo
+import cn.gdeiassistant.model.Schedule
+import cn.gdeiassistant.model.UserProfileSummary
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var scheduleRepository: ScheduleRepository
+    private lateinit var cardRepository: CardRepository
+    private lateinit var announcementRepository: AnnouncementRepository
+    private lateinit var profileRepository: ProfileRepository
+    private lateinit var sessionManager: SessionManager
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        scheduleRepository = mock()
+        cardRepository = mock()
+        announcementRepository = mock()
+        profileRepository = mock()
+        sessionManager = mock()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun refreshUsesProfileNicknameAndSortsTodayCourses() = runTest(testDispatcher) {
+        whenever(sessionManager.currentUsername()).thenReturn("  alice  ")
+        whenever(scheduleRepository.loadTodaySchedule()).thenReturn(
+            Result.success(
+                listOf(
+                    Schedule(id = "b", position = 3),
+                    Schedule(id = "a", position = 1),
+                    Schedule(id = "c", position = null)
+                )
+            )
+        )
+        whenever(cardRepository.getCardInfo()).thenReturn(Result.success(CardInfo(cardNumber = "20230001")))
+        whenever(announcementRepository.getAnnouncements(limit = 5)).thenReturn(
+            Result.success(listOf(AnnouncementItem(id = "1", title = "通知", content = "内容", publishTime = "2026-04-03")))
+        )
+        whenever(profileRepository.getProfile()).thenReturn(
+            Result.success(UserProfileSummary(username = "alice", nickname = "校园助手"))
+        )
+
+        val viewModel = HomeViewModel(
+            scheduleRepository,
+            cardRepository,
+            announcementRepository,
+            profileRepository,
+            sessionManager
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertEquals("校园助手", state.displayName)
+        assertEquals(listOf("a", "b", "c"), state.todayCourses.map { it.id })
+        assertEquals("20230001", state.cardInfo?.cardNumber)
+        assertEquals(1, state.notices.size)
+        verify(announcementRepository).getAnnouncements(limit = 5)
+    }
+
+    @Test
+    fun refreshFallsBackToSessionUsernameAndExposesRepositoryErrors() = runTest(testDispatcher) {
+        whenever(sessionManager.currentUsername()).thenReturn("  alice  ")
+        whenever(scheduleRepository.loadTodaySchedule()).thenReturn(Result.failure(IllegalStateException("课表加载失败")))
+        whenever(cardRepository.getCardInfo()).thenReturn(Result.failure(IllegalStateException("校园卡加载失败")))
+        whenever(announcementRepository.getAnnouncements(limit = 5)).thenReturn(Result.failure(IllegalStateException("公告加载失败")))
+        whenever(profileRepository.getProfile()).thenReturn(Result.failure(IllegalStateException("资料加载失败")))
+
+        val viewModel = HomeViewModel(
+            scheduleRepository,
+            cardRepository,
+            announcementRepository,
+            profileRepository,
+            sessionManager
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertEquals("alice", state.displayName)
+        assertEquals("课表加载失败", state.scheduleError)
+        assertEquals("校园卡加载失败", state.cardError)
+        assertEquals("公告加载失败", state.noticeError)
+        assertEquals(0, state.todayCourses.size)
+        assertEquals(0, state.notices.size)
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
@@ -1,0 +1,92 @@
+package cn.gdeiassistant.ui.profile
+
+import android.content.Context
+import cn.gdeiassistant.R
+import cn.gdeiassistant.data.SettingsRepository
+import cn.gdeiassistant.network.NetworkEnvironment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileSettingsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var mockModeFlow: MutableStateFlow<Boolean>
+    private lateinit var networkEnvironmentFlow: MutableStateFlow<NetworkEnvironment>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        context = mock()
+        settingsRepository = mock()
+        mockModeFlow = MutableStateFlow(false)
+        networkEnvironmentFlow = MutableStateFlow(NetworkEnvironment.STAGING)
+
+        whenever(settingsRepository.isMockModeEnabled).thenReturn(mockModeFlow)
+        whenever(settingsRepository.networkEnvironment).thenReturn(networkEnvironmentFlow)
+        whenever(context.getString(R.string.profile_settings_toggle_failed)).thenReturn("切换失败")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun stateTracksMockModeAndNetworkEnvironmentFlows() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository)
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.state.value.isMockModeEnabled)
+        assertEquals(NetworkEnvironment.STAGING, viewModel.state.value.networkEnvironment)
+        assertEquals(NetworkEnvironment.STAGING.baseUrl, viewModel.state.value.environmentBaseUrl)
+
+        mockModeFlow.value = true
+        networkEnvironmentFlow.value = NetworkEnvironment.DEV
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.state.value.isMockModeEnabled)
+        assertEquals(NetworkEnvironment.DEV, viewModel.state.value.networkEnvironment)
+        assertEquals(NetworkEnvironment.DEV.baseUrl, viewModel.state.value.environmentBaseUrl)
+    }
+
+    @Test
+    fun setNetworkEnvironmentDelegatesToRepository() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository)
+
+        viewModel.setNetworkEnvironment(NetworkEnvironment.PROD)
+        advanceUntilIdle()
+
+        verify(settingsRepository).setNetworkEnvironment(NetworkEnvironment.PROD)
+    }
+
+    @Test
+    fun setNetworkEnvironmentEmitsReadableFailureMessage() = runTest(testDispatcher) {
+        doThrow(IllegalStateException("保存失败")).whenever(settingsRepository).setNetworkEnvironment(NetworkEnvironment.DEV)
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository)
+        val eventDeferred = async { viewModel.events.first() }
+
+        viewModel.setNetworkEnvironment(NetworkEnvironment.DEV)
+        advanceUntilIdle()
+
+        assertEquals(ProfileSettingsEvent.ShowMessage("保存失败"), eventDeferred.await())
+    }
+}


### PR DESCRIPTION
## Summary
- extend Android CI beyond unit tests by adding `lintDebug` and `assembleDebug`
- add focused tests for session restoration, the home view model, and profile settings behavior
- clean up a small set of Compose / resource issues that were blocking lint from getting past the first batch of errors

## Why
The project already had good network-layer coverage, but CI still only exercised `testDebugUnitTest`. That left lint and installable debug builds outside the normal quality gate. The new tests target login/session and settings paths that are central to environment switching and user state.

## Validation
- `./gradlew testDebugUnitTest assembleDebug --no-daemon -Dorg.gradle.jvmargs='-Xmx4g -Dfile.encoding=UTF-8' --console=plain`

## Notes
- local `lintDebug` was exercised during development and the immediate blocking errors were fixed, but a full local lint run on this machine remained too slow to finish reliably; the new CI job should be treated as the authoritative lint signal
- the screen/resource edits in this PR are limited to lint-driven cleanup needed to support the stronger CI gate