### PR TITLE
[codex] configure certificate pinning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Base64
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
@@ -10,6 +12,60 @@ val stagingBaseUrl = providers.gradleProperty("GDEI_BASE_URL_STAGING").orNull
     ?: "https://gdeiassistant.azurewebsites.net/"
 val prodBaseUrl = providers.gradleProperty("GDEI_BASE_URL_PROD").orNull
     ?: "https://gdeiassistant.cn/"
+val certificatePins = providers.gradleProperty("GDEI_CERTIFICATE_PINS").orNull.orEmpty()
+val requireCertificatePins = providers.gradleProperty("GDEI_REQUIRE_CERTIFICATE_PINS")
+    .map { it.toBoolean() }
+    .orElse(false)
+    .get()
+val placeholderCertificatePins = setOf(
+    "sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+    "sha256/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC="
+)
+
+fun parseCertificatePins(rawPins: String): List<String> = rawPins
+    .split(Regex("[,;\\s]+"))
+    .map { it.trim() }
+    .filter { it.isNotEmpty() }
+    .map { pin -> if (pin.startsWith("sha256/")) pin else "sha256/$pin" }
+
+fun isValidSha256CertificatePin(pin: String): Boolean {
+    if (!pin.startsWith("sha256/")) return false
+    val encodedHash = pin.removePrefix("sha256/")
+    return runCatching {
+        Base64.getDecoder().decode(encodedHash).size == 32
+    }.getOrDefault(false)
+}
+
+val parsedCertificatePins = parseCertificatePins(certificatePins)
+
+require(parsedCertificatePins.none { it in placeholderCertificatePins }) {
+    "GDEI_CERTIFICATE_PINS must contain real public-key SHA-256 pins, not placeholders."
+}
+require(parsedCertificatePins.all(::isValidSha256CertificatePin)) {
+    "GDEI_CERTIFICATE_PINS entries must be sha256/ pins with 32-byte base64-encoded public key hashes."
+}
+if (requireCertificatePins) {
+    require(parsedCertificatePins.isNotEmpty()) {
+        "GDEI_CERTIFICATE_PINS is required when GDEI_REQUIRE_CERTIFICATE_PINS=true."
+    }
+}
+
+fun String.asBuildConfigString(): String = buildString {
+    append('"')
+    this@asBuildConfigString.forEach { char ->
+        append(
+            when (char) {
+                '\\' -> "\\\\"
+                '"' -> "\\\""
+                '\n' -> "\\n"
+                '\r' -> "\\r"
+                '\t' -> "\\t"
+                else -> char.toString()
+            }
+        )
+    }
+    append('"')
+}
 
 android {
     namespace = "cn.gdeiassistant"
@@ -27,6 +83,7 @@ android {
         buildConfigField("String", "BASE_URL_STAGING", "\"$stagingBaseUrl\"")
         buildConfigField("String", "BASE_URL_PROD", "\"$prodBaseUrl\"")
         buildConfigField("String", "DEFAULT_NETWORK_ENVIRONMENT", "\"prod\"")
+        buildConfigField("String", "CERTIFICATE_PINS", certificatePins.asBuildConfigString())
     }
 
     buildTypes {

--- a/app/src/main/java/cn/gdeiassistant/di/NetworkModule.kt
+++ b/app/src/main/java/cn/gdeiassistant/di/NetworkModule.kt
@@ -50,6 +50,11 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
+    private val placeholderCertificatePins = setOf(
+        "sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+        "sha256/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC="
+    )
+
     @Provides
     @Singleton
     fun provideRequestIdInterceptor(): RequestIdInterceptor = RequestIdInterceptor()
@@ -69,33 +74,42 @@ object NetworkModule {
         responseInterceptor: ResponseInterceptor,
         localeInterceptor: LocaleInterceptor
     ): OkHttpClient {
-        val prodHost = runCatching {
+        val apiHost = runCatching {
             BuildConfig.BASE_URL.toHttpUrl().host
         }.getOrDefault("gdeiassistant.cn")
 
-        val certificatePinner = CertificatePinner.Builder()
-            // TODO: 替换为服务端证书实际的 SHA-256 指纹，可通过以下命令获取：
-            // openssl s_client -connect <host>:443 | openssl x509 -pubkey -noout |
-            //   openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
-            .add(prodHost, "sha256/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
-            // 备用指纹（证书轮换时使用）
-            .add(prodHost, "sha256/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=")
-            .build()
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(NetworkConstants.CONNECT_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
+            .readTimeout(NetworkConstants.READ_WRITE_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
+            .writeTimeout(NetworkConstants.READ_WRITE_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
+            .cookieJar(sessionManager.cookieJar)
+            .addInterceptor(requestIdInterceptor)        // 1. Assign X-Request-ID before anything else
+            .addInterceptor(localeInterceptor)           // 2. Add Accept-Language
+            .addInterceptor(baseUrlOverrideInterceptor)  // 3. Rewrite base URL for environment
+            .addInterceptor(networkLoggingInterceptor)   // 4. Log request+response timing
+            .addInterceptor(MockInterceptor())           // 5. Short-circuit with mock data if enabled
+            .addInterceptor(authInterceptor)             // 6. Attach Bearer token
+            .addInterceptor(responseInterceptor)         // 7. Handle HTTP errors
 
-        return OkHttpClient.Builder()
-        .connectTimeout(NetworkConstants.CONNECT_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
-        .readTimeout(NetworkConstants.READ_WRITE_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
-        .writeTimeout(NetworkConstants.READ_WRITE_TIMEOUT_SECONDS.toLong(), TimeUnit.SECONDS)
-        .certificatePinner(certificatePinner)
-        .cookieJar(sessionManager.cookieJar)
-        .addInterceptor(requestIdInterceptor)        // 1. Assign X-Request-ID before anything else
-        .addInterceptor(localeInterceptor)           // 2. Add Accept-Language
-        .addInterceptor(baseUrlOverrideInterceptor)  // 3. Rewrite base URL for environment
-        .addInterceptor(networkLoggingInterceptor)   // 4. Log request+response timing
-        .addInterceptor(MockInterceptor())           // 5. Short-circuit with mock data if enabled
-        .addInterceptor(authInterceptor)             // 6. Attach Bearer token
-        .addInterceptor(responseInterceptor)         // 7. Handle HTTP errors
-        .build()
+        buildCertificatePinner(apiHost)?.let(builder::certificatePinner)
+        return builder.build()
+    }
+
+    private fun buildCertificatePinner(host: String): CertificatePinner? {
+        val pins = BuildConfig.CERTIFICATE_PINS
+            .split(",", ";", "\n", "\t", " ")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { pin -> if (pin.startsWith("sha256/")) pin else "sha256/$pin" }
+            .filterNot { it in placeholderCertificatePins }
+
+        if (pins.isEmpty()) {
+            return null
+        }
+
+        return CertificatePinner.Builder().apply {
+            pins.forEach { add(host, it) }
+        }.build()
     }
 
     @Provides


### PR DESCRIPTION
## What
- Replace hardcoded placeholder certificate pins with a Gradle-configurable `GDEI_CERTIFICATE_PINS` value.
- Add optional `GDEI_REQUIRE_CERTIFICATE_PINS` validation for release environments that should fail fast without real pins.
- Only install OkHttp `CertificatePinner` when real pins are configured.

## Why
The previous placeholder pins would either break production traffic if enabled or give a false sense of security if left in place.

## Impact
Default local builds keep working without pins. Real deployments can inject SHA-256 public-key pins through Gradle properties.

## Checks
- `./gradlew :app:compileDebugKotlin --no-daemon`
- `git diff --check`