### PR TITLE
[codex] log upgrade check failures

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/service/UpgradeService.kt
+++ b/app/src/main/java/cn/gdeiassistant/service/UpgradeService.kt
@@ -14,12 +14,16 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.logging.Level
+import java.util.logging.Logger
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class UpgradeService : LifecycleService() {
 
     @Inject lateinit var upgradeApi: UpgradeApi
+
+    private val logger = Logger.getLogger(UpgradeService::class.java.name)
 
     override fun onCreate() { super.onCreate() }
 
@@ -62,7 +66,9 @@ class UpgradeService : LifecycleService() {
                         })
                     }
                 }
-            } catch (_: Exception) { }
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "Upgrade check failed", e)
+            }
             stopSelf()
         }
     }

--- a/app/src/main/java/cn/gdeiassistant/ui/lostfound/LostFoundScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/lostfound/LostFoundScreen.kt
@@ -434,6 +434,7 @@ fun LostFoundProfileScreen(navController: NavHostController) {
                         targetState = state.selectedTab to state.visibleItems,
                         label = "lost_found_profile_tab"
                     ) { contentState ->
+                        val selectedTab = contentState.first
                         val visibleItems = contentState.second
                         if (visibleItems.isEmpty()) {
                             Box(
@@ -452,7 +453,7 @@ fun LostFoundProfileScreen(navController: NavHostController) {
                                 visibleItems.forEach { item ->
                                     LostFoundProfileCard(
                                         item = item,
-                                        tab = state.selectedTab,
+                                        tab = selectedTab,
                                         onOpen = { navController.navigate(Routes.lostFoundDetail(item.id)) },
                                         onEdit = { navController.navigate(Routes.lostFoundEdit(item.id)) },
                                         onRequestMarkDidFound = { pendingMarkItemId = item.id }

--- a/app/src/main/java/cn/gdeiassistant/ui/marketplace/MarketplaceScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/marketplace/MarketplaceScreen.kt
@@ -445,6 +445,7 @@ fun MarketplaceProfileScreen(navController: NavHostController) {
                         targetState = state.selectedTab to state.visibleItems,
                         label = "marketplace_profile_tab"
                     ) { contentState ->
+                        val selectedTab = contentState.first
                         val visibleItems = contentState.second
                         if (visibleItems.isEmpty()) {
                             Box(
@@ -463,7 +464,7 @@ fun MarketplaceProfileScreen(navController: NavHostController) {
                                 visibleItems.forEach { item ->
                                     MarketplaceProfileCard(
                                         item = item,
-                                        tab = state.selectedTab,
+                                        tab = selectedTab,
                                         onOpen = { navController.navigate(Routes.marketplaceDetail(item.id)) },
                                         onEdit = { navController.navigate(Routes.marketplaceEdit(item.id)) },
                                         onRequestStateChange = { request ->

--- a/app/src/main/java/cn/gdeiassistant/ui/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/schedule/ScheduleScreen.kt
@@ -429,11 +429,12 @@ private fun TodayAgendaCard(
             targetState = Triple(isCurrentWeek, selectedWeek, courses),
             label = "schedule_focus_courses"
         ) { contentState ->
+            val contentIsCurrentWeek = contentState.first
             val currentCourses = contentState.third
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 if (currentCourses.isEmpty()) {
                     Text(
-                        text = if (isCurrentWeek) emptyCurrentText else emptyOtherText,
+                        text = if (contentIsCurrentWeek) emptyCurrentText else emptyOtherText,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )


### PR DESCRIPTION
## Summary
- log unexpected upgrade check failures instead of silently swallowing them
- keep the upgrade service self-stop behavior unchanged after failures
- use AnimatedContent target-state values in three existing profile/schedule blocks to avoid stale-state lint issues

## Validation
- `./gradlew --no-daemon :app:compileDebugKotlin --console=plain`
- `./gradlew --no-daemon :app:testDebugUnitTest --console=plain`
- `./gradlew --no-daemon :app:assembleDebug --console=plain`
- `git diff --check`

Note: local `lintDebug` did not complete in this macOS shell after several minutes; the PR CI still runs `./gradlew lintDebug` on Ubuntu.