### PR TITLE
[codex] use stable delivery pickup placeholder

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/DeliveryRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/DeliveryRepository.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val DELIVERY_PLACEHOLDER_PICKUP_CODE = "00000000000"
+
 @Singleton
 class DeliveryRepository @Inject constructor(
     private val deliveryApi: DeliveryApi
@@ -72,11 +74,11 @@ class DeliveryRepository @Inject constructor(
         safeJsonResultCall { deliveryApi.deleteOrder(orderId) }
     }
 
-    suspend fun publish(draft: DeliveryDraft, taskName: String, defaultPickupCode: String): Result<Unit> = withContext(Dispatchers.IO) {
+    suspend fun publish(draft: DeliveryDraft, taskName: String): Result<Unit> = withContext(Dispatchers.IO) {
         safeJsonResultCall {
             deliveryApi.publish(
                 name = taskName,
-                number = draft.pickupNumber.ifBlank { defaultPickupCode },
+                number = draft.pickupNumber.ifBlank { DELIVERY_PLACEHOLDER_PICKUP_CODE },
                 phone = draft.phone,
                 price = String.format("%.2f", draft.price),
                 company = draft.pickupPlace,

--- a/app/src/main/java/cn/gdeiassistant/ui/delivery/DeliveryViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/delivery/DeliveryViewModel.kt
@@ -271,8 +271,7 @@ class DeliveryPublishViewModel @Inject constructor(
                             address = trimmedAddress,
                             remarks = trimmedRemarks
                         ),
-                        taskName = context.getString(R.string.delivery_task_name),
-                        defaultPickupCode = context.getString(R.string.delivery_default_pickup_code)
+                        taskName = context.getString(R.string.delivery_task_name)
                     )
                         .onSuccess {
                             _state.update { it.copy(isSubmitting = false) }

--- a/app/src/test/java/cn/gdeiassistant/data/DeliveryRepositoryDisplaySeparationTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/DeliveryRepositoryDisplaySeparationTest.kt
@@ -1,17 +1,85 @@
 package cn.gdeiassistant.data
 
+import cn.gdeiassistant.model.DeliveryDraft
 import cn.gdeiassistant.model.DeliveryOrder
 import cn.gdeiassistant.model.DeliveryOrderState
 import cn.gdeiassistant.model.DeliveryTrade
+import cn.gdeiassistant.model.JsonResult
+import cn.gdeiassistant.network.api.DeliveryApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 /**
  * Verifies that DeliveryRepository returns raw domain data without display strings.
  * Display formatting is now the responsibility of DeliveryDisplayMapper in the UI layer.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class DeliveryRepositoryDisplaySeparationTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var deliveryApi: DeliveryApi
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        deliveryApi = mock()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun publishUsesStablePlaceholderPickupCodeForBlankDraftValue() = runTest(testDispatcher) {
+        whenever(
+            deliveryApi.publish(
+                name = "代收",
+                number = "00000000000",
+                phone = "13800138000",
+                price = "5.50",
+                company = "菜鸟驿站",
+                address = "南苑5栋307",
+                remarks = "轻拿轻放"
+            )
+        ).thenReturn(JsonResult(success = true))
+
+        val repository = DeliveryRepository(deliveryApi)
+        val result = repository.publish(
+            draft = DeliveryDraft(
+                pickupPlace = "菜鸟驿站",
+                pickupNumber = "",
+                phone = "13800138000",
+                price = 5.5,
+                address = "南苑5栋307",
+                remarks = "轻拿轻放"
+            ),
+            taskName = "代收"
+        )
+
+        assertTrue(result.isSuccess)
+        verify(deliveryApi).publish(
+            name = "代收",
+            number = "00000000000",
+            phone = "13800138000",
+            price = "5.50",
+            company = "菜鸟驿站",
+            address = "南苑5栋307",
+            remarks = "轻拿轻放"
+        )
+    }
 
     @Test
     fun deliveryOrderWithNullFieldsReturnsEmptyStringsNotDisplayText() {


### PR DESCRIPTION
## Summary
- Stop sending localized display text as the default delivery pickup code.
- Let `DeliveryRepository` substitute a stable backend-compatible `00000000000` placeholder when the draft pickup number is blank.
- Add regression coverage for the blank pickup-number publish payload.

## Validation
- `./gradlew testDebugUnitTest --tests 'cn.gdeiassistant.data.DeliveryRepositoryDisplaySeparationTest' --console=plain`
- `./gradlew testDebugUnitTest --console=plain`
- `./gradlew assembleDebug --console=plain`
- `git diff --check`