### PR TITLE
[codex] align photograph content limit

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/photograph/PhotographViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/photograph/PhotographViewModel.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val PHOTOGRAPH_CONTENT_MAX_LENGTH = 50
+
 data class PhotographUiState(
     val selectedCategory: PhotographCategory = PhotographCategory.CAMPUS,
     val stats: PhotographStats = PhotographStats(0, 0, 0),
@@ -255,7 +257,7 @@ class PhotographPublishViewModel @Inject constructor(
         when {
             trimmedTitle.isBlank() -> emitMessage(context.getString(R.string.photograph_publish_title_required))
             trimmedTitle.length > 25 -> emitMessage(context.getString(R.string.photograph_publish_title_limit))
-            trimmedContent.length > 150 -> emitMessage(context.getString(R.string.photograph_publish_content_limit))
+            trimmedContent.length > PHOTOGRAPH_CONTENT_MAX_LENGTH -> emitMessage(context.getString(R.string.photograph_publish_content_limit))
             _state.value.images.isEmpty() -> emitMessage(context.getString(R.string.photograph_publish_image_required))
             _state.value.images.size > 4 -> emitMessage(context.getString(R.string.photograph_publish_image_limit))
             else -> {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1160,7 +1160,7 @@
     <string name="photograph_publish_failed">Failed to publish</string>
     <string name="photograph_publish_title_required">Please enter a title</string>
     <string name="photograph_publish_title_limit">Title cannot exceed 25 characters</string>
-    <string name="photograph_publish_content_limit">Content cannot exceed 150 characters</string>
+    <string name="photograph_publish_content_limit">Content cannot exceed 50 characters</string>
     <string name="photograph_publish_image_required">Please select at least one photo</string>
     <string name="photograph_publish_image_limit">Maximum 4 photos allowed</string>
     <string name="photograph_publish_read_failed">Failed to read photo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1160,7 +1160,7 @@
     <string name="photograph_publish_failed">投稿に失敗しました</string>
     <string name="photograph_publish_title_required">タイトルを入力してください</string>
     <string name="photograph_publish_title_limit">タイトルは25文字以内で入力してください</string>
-    <string name="photograph_publish_content_limit">内容は150文字以内で入力してください</string>
+    <string name="photograph_publish_content_limit">内容は50文字以内で入力してください</string>
     <string name="photograph_publish_image_required">画像を1枚以上選択してください</string>
     <string name="photograph_publish_image_limit">画像は最大4枚までアップロードできます</string>
     <string name="photograph_publish_read_failed">画像の読み込みに失敗しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1160,7 +1160,7 @@
     <string name="photograph_publish_failed">등록 실패</string>
     <string name="photograph_publish_title_required">제목을 입력해 주세요</string>
     <string name="photograph_publish_title_limit">제목은 25자를 초과할 수 없습니다</string>
-    <string name="photograph_publish_content_limit">내용은 150자를 초과할 수 없습니다</string>
+    <string name="photograph_publish_content_limit">내용은 50자를 초과할 수 없습니다</string>
     <string name="photograph_publish_image_required">이미지를 최소 1장 선택해 주세요</string>
     <string name="photograph_publish_image_limit">최대 4장까지 업로드할 수 있습니다</string>
     <string name="photograph_publish_read_failed">이미지 읽기 실패</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1159,7 +1159,7 @@
     <string name="photograph_publish_failed">發佈失敗</string>
     <string name="photograph_publish_title_required">請輸入標題</string>
     <string name="photograph_publish_title_limit">標題不能超過 25 個字</string>
-    <string name="photograph_publish_content_limit">內容不能超過 150 個字</string>
+    <string name="photograph_publish_content_limit">內容不能超過 50 個字</string>
     <string name="photograph_publish_image_required">請至少選擇一張圖片</string>
     <string name="photograph_publish_image_limit">最多上傳 4 張圖片</string>
     <string name="photograph_publish_read_failed">讀取圖片失敗</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1159,7 +1159,7 @@
     <string name="photograph_publish_failed">發佈失敗</string>
     <string name="photograph_publish_title_required">請輸入標題</string>
     <string name="photograph_publish_title_limit">標題不能超過 25 個字</string>
-    <string name="photograph_publish_content_limit">內容不能超過 150 個字</string>
+    <string name="photograph_publish_content_limit">內容不能超過 50 個字</string>
     <string name="photograph_publish_image_required">請至少選擇一張圖片</string>
     <string name="photograph_publish_image_limit">最多上傳 4 張圖片</string>
     <string name="photograph_publish_read_failed">讀取圖片失敗</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1159,7 +1159,7 @@
     <string name="photograph_publish_failed">发布失败</string>
     <string name="photograph_publish_title_required">请输入标题</string>
     <string name="photograph_publish_title_limit">标题不能超过 25 个字</string>
-    <string name="photograph_publish_content_limit">内容不能超过 150 个字</string>
+    <string name="photograph_publish_content_limit">内容不能超过 50 个字</string>
     <string name="photograph_publish_image_required">请至少选择一张图片</string>
     <string name="photograph_publish_image_limit">最多上传 4 张图片</string>
     <string name="photograph_publish_read_failed">读取图片失败</string>


### PR DESCRIPTION
## Summary
- Align Android photograph publish content validation with the backend 50-character contract.
- Update localized validation messages from 150 to 50 characters.

## Validation
- `./gradlew testDebugUnitTest --no-daemon --console=plain`
- `./gradlew lintDebug --no-daemon --console=plain`
- `git diff --check`