### PR TITLE
[codex] let photograph derive image count

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/PhotographRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/PhotographRepository.kt
@@ -110,7 +110,6 @@ class PhotographRepository @Inject constructor(
             photographApi.publish(
                 title = title.toRequestBody(),
                 content = content.toRequestBody(),
-                count = images.size.toString().toRequestBody(),
                 type = category.publishType.toString().toRequestBody(),
                 images = parts
             )

--- a/app/src/main/java/cn/gdeiassistant/network/api/PhotographApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/PhotographApi.kt
@@ -67,7 +67,6 @@ interface PhotographApi {
     suspend fun publish(
         @Part("title") title: RequestBody,
         @Part("content") content: RequestBody,
-        @Part("count") count: RequestBody,
         @Part("type") type: RequestBody,
         @Part images: List<MultipartBody.Part>
     ): JsonResult


### PR DESCRIPTION
## Summary
- Remove the redundant multipart `count` field from photograph publish requests.
- Keep topic publish requests unchanged because that contract still sends count explicitly.
- Let the backend derive photograph image count from uploaded image parts.

## Validation
- `./gradlew testDebugUnitTest --no-daemon --console=plain`
- `./gradlew lintDebug --no-daemon --console=plain`
- `git diff --check`