### PR TITLE
[codex] align topic publish contract

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/TopicRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/TopicRepository.kt
@@ -79,7 +79,6 @@ class TopicRepository @Inject constructor(
             topicApi.publish(
                 topic = draft.topic.trim().toPlainBody(),
                 content = draft.content.trim().toPlainBody(),
-                count = images.size.toString().toPlainBody(),
                 images = images.mapIndexed { index, uri -> uriToPart(uri = uri, index = index + 1) }
             )
         }
@@ -121,7 +120,7 @@ class TopicRepository @Inject constructor(
             ?: throw IllegalStateException(context.getString(R.string.topic_publish_read_failed))
         val fileName = queryDisplayName(uri).ifBlank { "topic-${UUID.randomUUID()}.jpg" }
         return MultipartBody.Part.createFormData(
-            "image$index",
+            "images",
             fileName,
             bytes.toRequestBody(mimeType.toMediaTypeOrNull())
         )

--- a/app/src/main/java/cn/gdeiassistant/network/api/TopicApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/TopicApi.kt
@@ -46,7 +46,6 @@ interface TopicApi {
     suspend fun publish(
         @Part("topic") topic: RequestBody,
         @Part("content") content: RequestBody,
-        @Part("count") count: RequestBody,
         @Part images: List<MultipartBody.Part>
     ): JsonResult
 

--- a/app/src/test/java/cn/gdeiassistant/data/TopicPublishContractTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/TopicPublishContractTest.kt
@@ -1,0 +1,59 @@
+package cn.gdeiassistant.data
+
+import cn.gdeiassistant.network.api.TopicApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.http.Part
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+class TopicPublishContractTest {
+
+    private val workingDir: Path = Path.of(System.getProperty("user.dir")).toAbsolutePath()
+
+    @Test
+    fun topicPublishApiDoesNotSendRedundantCountPart() {
+        val publishMethod = TopicApi::class.java.methods.first { it.name == "publish" }
+        val partNames = publishMethod.parameterAnnotations
+            .flatMap { annotations -> annotations.filterIsInstance<Part>() }
+            .map { it.value }
+
+        assertFalse("Backend derives topic count from uploaded images/imageKeys.", partNames.contains("count"))
+    }
+
+    @Test
+    fun topicMultipartImagesUseBackendArrayFieldName() {
+        val source = sourceFile("app/src/main/java/cn/gdeiassistant/data/TopicRepository.kt")
+        val createFormDataBlock = source.substringAfter("MultipartBody.Part.createFormData(")
+            .substringBefore(")")
+
+        assertTrue(
+            "Topic image uploads must use backend's MultipartFile[] field name.",
+            createFormDataBlock.contains("\"images\"")
+        )
+        assertFalse(
+            "Topic image uploads should not use image1/image2 style fields.",
+            createFormDataBlock.contains("\"image\$index\"")
+        )
+    }
+
+    private fun sourceFile(relativePath: String): String {
+        return String(Files.readAllBytes(resolveProjectPath(relativePath)), StandardCharsets.UTF_8)
+    }
+
+    private fun resolveProjectPath(relativePath: String): Path {
+        val directPath = workingDir.resolve(relativePath)
+        if (Files.exists(directPath)) {
+            return directPath
+        }
+
+        val parentPath = workingDir.parent?.resolve(relativePath)
+        if (parentPath != null && Files.exists(parentPath)) {
+            return parentPath
+        }
+
+        return directPath
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the redundant multipart `count` part from topic publish requests.
- Send topic image uploads using the backend `images` multipart array field instead of `image1` / `image2` style fields.
- Add a unit regression test for the topic publish API contract and multipart field name.

## Validation
- `./gradlew testDebugUnitTest --tests cn.gdeiassistant.data.TopicPublishContractTest --no-daemon --console=plain`
- `./gradlew lintDebug --no-daemon --console=plain`
- `git diff --check`