### PR TITLE
Add campus credential consent and controls

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/AuthRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/AuthRepository.kt
@@ -2,6 +2,8 @@ package cn.gdeiassistant.data
 
 import android.content.Context
 import cn.gdeiassistant.R
+import cn.gdeiassistant.model.CampusCredentialConsentMetadata
+import cn.gdeiassistant.model.LoginRequest
 import cn.gdeiassistant.model.UserLoginResult
 import cn.gdeiassistant.network.api.AuthApi
 import cn.gdeiassistant.network.safeApiCall
@@ -21,9 +23,22 @@ class AuthRepository @Inject constructor(
     private val sessionManager: SessionManager
 ) {
 
-    suspend fun login(username: String, password: String): Result<Unit> = withContext(Dispatchers.IO) {
+    suspend fun login(
+        username: String,
+        password: String,
+        consentMetadata: CampusCredentialConsentMetadata? = null
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         safeApiCall {
-            authApi.login(mapOf("username" to username, "password" to password))
+            authApi.login(
+                LoginRequest(
+                    username = username,
+                    password = password,
+                    campusCredentialConsent = consentMetadata?.let { true },
+                    consentScene = consentMetadata?.scene,
+                    policyDate = consentMetadata?.policyDate,
+                    effectiveDate = consentMetadata?.effectiveDate
+                )
+            )
         }.mapCatching { response ->
             val data: UserLoginResult = response
                 ?: throw IllegalStateException(context.getString(R.string.service_unavailable))

--- a/app/src/main/java/cn/gdeiassistant/data/CampusCredentialRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/CampusCredentialRepository.kt
@@ -1,0 +1,69 @@
+package cn.gdeiassistant.data
+
+import cn.gdeiassistant.model.CampusCredentialConsentMetadata
+import cn.gdeiassistant.model.CampusCredentialStatus
+import cn.gdeiassistant.model.maskAccount
+import cn.gdeiassistant.network.api.CampusCredentialApi
+import cn.gdeiassistant.network.api.CampusCredentialConsentRequest
+import cn.gdeiassistant.network.api.CampusCredentialQuickAuthRequest
+import cn.gdeiassistant.network.api.CampusCredentialStatusDto
+import cn.gdeiassistant.network.safeApiCall
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CampusCredentialRepository @Inject constructor(
+    private val campusCredentialApi: CampusCredentialApi
+) {
+
+    suspend fun getCampusCredentialStatus(): Result<CampusCredentialStatus> = withContext(Dispatchers.IO) {
+        safeApiCall { campusCredentialApi.getStatus() }
+            .map { it.toDomain() }
+    }
+
+    suspend fun recordCampusCredentialConsent(
+        metadata: CampusCredentialConsentMetadata
+    ): Result<CampusCredentialStatus> = withContext(Dispatchers.IO) {
+        safeApiCall {
+            campusCredentialApi.recordConsent(
+                CampusCredentialConsentRequest(
+                    scene = metadata.scene,
+                    policyDate = metadata.policyDate,
+                    effectiveDate = metadata.effectiveDate
+                )
+            )
+        }.map { it.toDomain() }
+    }
+
+    suspend fun revokeCampusCredentialConsent(): Result<CampusCredentialStatus> = withContext(Dispatchers.IO) {
+        safeApiCall { campusCredentialApi.revokeConsent() }
+            .map { it.toDomain() }
+    }
+
+    suspend fun deleteCampusCredential(): Result<CampusCredentialStatus> = withContext(Dispatchers.IO) {
+        safeApiCall { campusCredentialApi.deleteCredential() }
+            .map { it.toDomain() }
+    }
+
+    suspend fun setQuickAuthEnabled(enabled: Boolean): Result<CampusCredentialStatus> = withContext(Dispatchers.IO) {
+        safeApiCall {
+            campusCredentialApi.updateQuickAuth(CampusCredentialQuickAuthRequest(enabled = enabled))
+        }.map { it.toDomain() }
+    }
+
+    private fun CampusCredentialStatusDto?.toDomain(): CampusCredentialStatus {
+        return CampusCredentialStatus(
+            hasActiveConsent = this?.hasActiveConsent ?: false,
+            hasSavedCredential = this?.hasSavedCredential ?: false,
+            quickAuthEnabled = this?.quickAuthEnabled ?: false,
+            consentedAt = this?.consentedAt?.trim()?.takeIf(String::isNotBlank),
+            revokedAt = this?.revokedAt?.trim()?.takeIf(String::isNotBlank),
+            policyDate = this?.policyDate?.trim()?.takeIf(String::isNotBlank),
+            effectiveDate = this?.effectiveDate?.trim()?.takeIf(String::isNotBlank),
+            maskedCampusAccount = maskAccount(this?.maskedCampusAccount)
+                .takeIf(String::isNotBlank)
+        )
+    }
+}

--- a/app/src/main/java/cn/gdeiassistant/di/NetworkModule.kt
+++ b/app/src/main/java/cn/gdeiassistant/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import cn.gdeiassistant.network.api.AnnouncementApi
 import cn.gdeiassistant.network.api.AuthApi
 import cn.gdeiassistant.network.api.LibraryApi
 import cn.gdeiassistant.network.api.CardApi
+import cn.gdeiassistant.network.api.CampusCredentialApi
 import cn.gdeiassistant.network.api.CetApi
 import cn.gdeiassistant.network.api.ChargeApi
 import cn.gdeiassistant.network.api.DataCenterApi
@@ -124,6 +125,7 @@ object NetworkModule {
     @Provides @Singleton fun provideAnnouncementApi(retrofit: Retrofit): AnnouncementApi = retrofit.create(AnnouncementApi::class.java)
     @Provides @Singleton fun provideLibraryApi(retrofit: Retrofit): LibraryApi = retrofit.create(LibraryApi::class.java)
     @Provides @Singleton fun provideCardApi(retrofit: Retrofit): CardApi = retrofit.create(CardApi::class.java)
+    @Provides @Singleton fun provideCampusCredentialApi(retrofit: Retrofit): CampusCredentialApi = retrofit.create(CampusCredentialApi::class.java)
     @Provides @Singleton fun provideCetApi(retrofit: Retrofit): CetApi = retrofit.create(CetApi::class.java)
     @Provides @Singleton fun provideChargeApi(retrofit: Retrofit): ChargeApi = retrofit.create(ChargeApi::class.java)
     @Provides @Singleton fun provideDataCenterApi(retrofit: Retrofit): DataCenterApi = retrofit.create(DataCenterApi::class.java)

--- a/app/src/main/java/cn/gdeiassistant/model/AccountCenterModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/model/AccountCenterModels.kt
@@ -107,6 +107,29 @@ fun maskEmail(email: String?): String {
     return "${local.take(3)}***@$domain"
 }
 
+fun maskAccount(account: String?): String {
+    val normalized = account?.trim().orEmpty()
+    if (normalized.isBlank()) return ""
+    if (normalized.contains("*")) return normalized
+    return when {
+        normalized.length >= 8 -> "${normalized.take(2)}****${normalized.takeLast(2)}"
+        normalized.length >= 3 -> "${normalized.take(1)}***${normalized.takeLast(1)}"
+        normalized.length >= 2 -> "${normalized.take(1)}***"
+        else -> "*"
+    }
+}
+
+fun maskToken(token: String?): String {
+    val normalized = token?.trim().orEmpty()
+    if (normalized.isBlank()) return ""
+    if (normalized.contains("*")) return normalized
+    return when {
+        normalized.length >= 12 -> "${normalized.take(4)}****${normalized.takeLast(4)}"
+        normalized.length > 4 -> "${normalized.take(2)}***${normalized.takeLast(2)}"
+        else -> "***"
+    }
+}
+
 fun displayDeviceName(rawValue: String?): String {
     val value = rawValue.orEmpty()
         .replace("客户端", "")

--- a/app/src/main/java/cn/gdeiassistant/model/CampusCredentialModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/model/CampusCredentialModels.kt
@@ -1,0 +1,29 @@
+package cn.gdeiassistant.model
+
+import androidx.compose.runtime.Immutable
+import java.io.Serializable
+
+object CampusCredentialDefaults {
+    const val POLICY_DATE = "2026-04-25"
+    const val EFFECTIVE_DATE = "2026-05-11"
+    const val SCENE_LOGIN = "LOGIN"
+}
+
+@Immutable
+data class CampusCredentialConsentMetadata(
+    val scene: String = CampusCredentialDefaults.SCENE_LOGIN,
+    val policyDate: String = CampusCredentialDefaults.POLICY_DATE,
+    val effectiveDate: String = CampusCredentialDefaults.EFFECTIVE_DATE
+) : Serializable
+
+@Immutable
+data class CampusCredentialStatus(
+    val hasActiveConsent: Boolean = false,
+    val hasSavedCredential: Boolean = false,
+    val quickAuthEnabled: Boolean = false,
+    val consentedAt: String? = null,
+    val revokedAt: String? = null,
+    val policyDate: String? = null,
+    val effectiveDate: String? = null,
+    val maskedCampusAccount: String? = null
+) : Serializable

--- a/app/src/main/java/cn/gdeiassistant/model/LoginRequest.kt
+++ b/app/src/main/java/cn/gdeiassistant/model/LoginRequest.kt
@@ -1,0 +1,14 @@
+package cn.gdeiassistant.model
+
+import androidx.compose.runtime.Immutable
+import java.io.Serializable
+
+@Immutable
+data class LoginRequest(
+    val username: String,
+    val password: String,
+    val campusCredentialConsent: Boolean? = null,
+    val consentScene: String? = null,
+    val policyDate: String? = null,
+    val effectiveDate: String? = null
+) : Serializable

--- a/app/src/main/java/cn/gdeiassistant/network/MockInterceptor.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/MockInterceptor.kt
@@ -3,6 +3,7 @@ package cn.gdeiassistant.network
 import cn.gdeiassistant.data.SettingsRepository
 import cn.gdeiassistant.network.mock.MockAcademicProvider
 import cn.gdeiassistant.network.mock.MockAuthProvider
+import cn.gdeiassistant.network.mock.MockCampusCredentialProvider
 import cn.gdeiassistant.network.mock.MockCampusProvider
 import cn.gdeiassistant.network.mock.MockCommunityProvider
 import cn.gdeiassistant.network.mock.MockInfoProvider
@@ -46,6 +47,11 @@ class MockInterceptor : Interceptor {
     private fun routeProfile(request: Request): String? {
         val path = request.url.encodedPath
         return when {
+            path.contains("api/campus-credential/status") -> MockCampusCredentialProvider.mockStatus(request)
+            path.contains("api/campus-credential/consent") -> MockCampusCredentialProvider.mockConsent(request)
+            path.contains("api/campus-credential/revoke") -> MockCampusCredentialProvider.mockRevoke(request)
+            path.contains("api/campus-credential/quick-auth") -> MockCampusCredentialProvider.mockQuickAuth(request)
+            path.endsWith("/api/campus-credential") && request.method == "DELETE" -> MockCampusCredentialProvider.mockDelete(request)
             path.contains("api/user/profile") -> MockProfileProvider.mockUserProfile(request)
             path.contains("api/profile/locations") -> MockProfileProvider.mockLocationList(request)
             path.contains("api/profile/options") -> MockProfileProvider.mockProfileOptions(request)

--- a/app/src/main/java/cn/gdeiassistant/network/api/AuthApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/AuthApi.kt
@@ -1,6 +1,7 @@
 package cn.gdeiassistant.network.api
 
 import cn.gdeiassistant.model.DataJsonResult
+import cn.gdeiassistant.model.LoginRequest
 import cn.gdeiassistant.model.UserLoginResult
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -12,6 +13,6 @@ interface AuthApi {
 
     @POST("api/auth/login")
     suspend fun login(
-        @Body body: Map<String, String>
+        @Body body: LoginRequest
     ): DataJsonResult<UserLoginResult>
 }

--- a/app/src/main/java/cn/gdeiassistant/network/api/CampusCredentialApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/CampusCredentialApi.kt
@@ -1,0 +1,50 @@
+package cn.gdeiassistant.network.api
+
+import cn.gdeiassistant.model.DataJsonResult
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+data class CampusCredentialStatusDto(
+    val hasActiveConsent: Boolean? = null,
+    val hasSavedCredential: Boolean? = null,
+    val quickAuthEnabled: Boolean? = null,
+    val consentedAt: String? = null,
+    val revokedAt: String? = null,
+    val policyDate: String? = null,
+    val effectiveDate: String? = null,
+    val maskedCampusAccount: String? = null
+)
+
+data class CampusCredentialConsentRequest(
+    val scene: String,
+    val policyDate: String,
+    val effectiveDate: String
+)
+
+data class CampusCredentialQuickAuthRequest(
+    val enabled: Boolean
+)
+
+interface CampusCredentialApi {
+
+    @GET("api/campus-credential/status")
+    suspend fun getStatus(): DataJsonResult<CampusCredentialStatusDto>
+
+    @POST("api/campus-credential/consent")
+    suspend fun recordConsent(
+        @Body body: CampusCredentialConsentRequest
+    ): DataJsonResult<CampusCredentialStatusDto>
+
+    @POST("api/campus-credential/revoke")
+    suspend fun revokeConsent(): DataJsonResult<CampusCredentialStatusDto>
+
+    @DELETE("api/campus-credential")
+    suspend fun deleteCredential(): DataJsonResult<CampusCredentialStatusDto>
+
+    @POST("api/campus-credential/quick-auth")
+    suspend fun updateQuickAuth(
+        @Body body: CampusCredentialQuickAuthRequest
+    ): DataJsonResult<CampusCredentialStatusDto>
+}

--- a/app/src/main/java/cn/gdeiassistant/network/mock/MockCampusCredentialProvider.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/mock/MockCampusCredentialProvider.kt
@@ -1,0 +1,86 @@
+package cn.gdeiassistant.network.mock
+
+import cn.gdeiassistant.model.CampusCredentialDefaults
+import cn.gdeiassistant.model.maskAccount
+import cn.gdeiassistant.network.mock.MockUtils.getBoolean
+import cn.gdeiassistant.network.mock.MockUtils.jsonObjectBody
+import okhttp3.Request
+
+object MockCampusCredentialProvider {
+
+    private data class MockCampusCredentialState(
+        val hasActiveConsent: Boolean = true,
+        val hasSavedCredential: Boolean = true,
+        val quickAuthAllowed: Boolean = true,
+        val consentedAt: String? = "2026-04-26 10:32:15",
+        val revokedAt: String? = null,
+        val policyDate: String = CampusCredentialDefaults.POLICY_DATE,
+        val effectiveDate: String = CampusCredentialDefaults.EFFECTIVE_DATE,
+        val campusAccount: String? = MockUtils.MOCK_STUDENT_NUMBER
+    )
+
+    private var state = MockCampusCredentialState()
+
+    fun mockStatus(request: Request): String = MockUtils.successDataJson(state.toPayload())
+
+    fun mockConsent(request: Request): String {
+        val body = request.jsonObjectBody()
+        state = state.copy(
+            hasActiveConsent = true,
+            consentedAt = "2026-04-26 11:00:00",
+            revokedAt = null,
+            policyDate = body?.getString("policyDate") ?: CampusCredentialDefaults.POLICY_DATE,
+            effectiveDate = body?.getString("effectiveDate") ?: CampusCredentialDefaults.EFFECTIVE_DATE,
+            campusAccount = state.campusAccount ?: MockUtils.MOCK_STUDENT_NUMBER
+        )
+        return MockUtils.successDataJson(state.toPayload(), message = "success")
+    }
+
+    fun mockRevoke(request: Request): String {
+        state = state.copy(
+            hasActiveConsent = false,
+            hasSavedCredential = false,
+            quickAuthAllowed = false,
+            revokedAt = "2026-04-26 11:30:00",
+            campusAccount = null
+        )
+        return MockUtils.successDataJson(state.toPayload(), message = "success")
+    }
+
+    fun mockDelete(request: Request): String {
+        state = state.copy(
+            hasActiveConsent = false,
+            hasSavedCredential = false,
+            quickAuthAllowed = false,
+            revokedAt = state.revokedAt ?: "2026-04-26 11:45:00",
+            campusAccount = null
+        )
+        return MockUtils.successDataJson(state.toPayload(), message = "success")
+    }
+
+    fun mockQuickAuth(request: Request): String {
+        val enabled = request.jsonObjectBody()?.getBoolean("enabled") ?: false
+        if (enabled && !state.hasActiveConsent) {
+            return MockUtils.failureJson("缺少有效授权，无法开启快速认证")
+        }
+        if (enabled && !state.hasSavedCredential) {
+            return MockUtils.failureJson("没有已保存的校园凭证，无法开启快速认证")
+        }
+        state = state.copy(quickAuthAllowed = enabled)
+        return MockUtils.successDataJson(state.toPayload(), message = "success")
+    }
+
+    private fun MockCampusCredentialState.toPayload(): Map<String, Any?> {
+        val quickAuthEnabled = hasActiveConsent && hasSavedCredential && quickAuthAllowed
+        return linkedMapOf(
+            "hasActiveConsent" to hasActiveConsent,
+            "hasSavedCredential" to hasSavedCredential,
+            "quickAuthEnabled" to quickAuthEnabled,
+            "consentedAt" to consentedAt,
+            "revokedAt" to revokedAt,
+            "policyDate" to policyDate,
+            "effectiveDate" to effectiveDate,
+            "maskedCampusAccount" to maskAccount(campusAccount)
+        )
+    }
+}

--- a/app/src/main/java/cn/gdeiassistant/network/mock/MockCampusCredentialProvider.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/mock/MockCampusCredentialProvider.kt
@@ -3,6 +3,7 @@ package cn.gdeiassistant.network.mock
 import cn.gdeiassistant.model.CampusCredentialDefaults
 import cn.gdeiassistant.model.maskAccount
 import cn.gdeiassistant.network.mock.MockUtils.getBoolean
+import cn.gdeiassistant.network.mock.MockUtils.getString
 import cn.gdeiassistant.network.mock.MockUtils.jsonObjectBody
 import okhttp3.Request
 

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DataObject
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -102,6 +103,7 @@ fun LoginScreen(navController: NavHostController) {
         state = uiState,
         onUsernameChange = viewModel::updateUsername,
         onPasswordChange = viewModel::updatePassword,
+        onCampusCredentialConsentChange = viewModel::setCampusCredentialConsentChecked,
         onMockModeChange = viewModel::setMockModeEnabled,
         onLoginClick = viewModel::login
     )
@@ -112,6 +114,7 @@ private fun LoginContent(
     state: LoginUiState,
     onUsernameChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
+    onCampusCredentialConsentChange: (Boolean) -> Unit,
     onMockModeChange: (Boolean) -> Unit,
     onLoginClick: () -> Unit
 ) {
@@ -137,6 +140,7 @@ private fun LoginContent(
                 state = state,
                 onUsernameChange = onUsernameChange,
                 onPasswordChange = onPasswordChange,
+                onCampusCredentialConsentChange = onCampusCredentialConsentChange,
                 onLoginClick = {
                     focusManager.clearFocus(force = true)
                     onLoginClick()
@@ -210,6 +214,7 @@ private fun LoginFormCard(
     state: LoginUiState,
     onUsernameChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
+    onCampusCredentialConsentChange: (Boolean) -> Unit,
     onLoginClick: () -> Unit
 ) {
     val focusManager = LocalFocusManager.current
@@ -306,6 +311,52 @@ private fun LoginFormCard(
                     }
                 )
             )
+
+            AnimatedVisibility(
+                visible = state.requiresCampusCredentialConsent,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = AppShapes.button,
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    border = androidx.compose.foundation.BorderStroke(
+                        1.dp,
+                        MaterialTheme.colorScheme.outlineVariant
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Checkbox(
+                            checked = state.isCampusCredentialConsentChecked,
+                            onCheckedChange = onCampusCredentialConsentChange,
+                            enabled = !state.isLoading,
+                            modifier = Modifier.testTag("login.campusCredentialConsent")
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.login_campus_credential_consent_label),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = stringResource(R.string.login_campus_credential_consent_note),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
 
             LoginActionButton(
                 text = if (state.isLoading) {

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
@@ -148,6 +148,7 @@ private fun LoginContent(
             )
             LoginMockCard(
                 enabled = state.isMockModeEnabled,
+                switchEnabled = !state.isLoading && !state.isMockModeUpdating,
                 onToggle = onMockModeChange
             )
         }
@@ -335,7 +336,7 @@ private fun LoginFormCard(
                         Checkbox(
                             checked = state.isCampusCredentialConsentChecked,
                             onCheckedChange = onCampusCredentialConsentChange,
-                            enabled = !state.isLoading,
+                            enabled = !state.isLoading && !state.isMockModeUpdating,
                             modifier = Modifier.testTag("login.campusCredentialConsent")
                         )
                         Spacer(modifier = Modifier.width(8.dp))
@@ -375,6 +376,7 @@ private fun LoginFormCard(
 @Composable
 private fun LoginMockCard(
     enabled: Boolean,
+    switchEnabled: Boolean,
     onToggle: (Boolean) -> Unit
 ) {
     Surface(
@@ -430,6 +432,7 @@ private fun LoginMockCard(
                 Switch(
                     checked = enabled,
                     onCheckedChange = onToggle,
+                    enabled = switchEnabled,
                     modifier = Modifier.testTag("login.mock.toggle")
                 )
             }

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
@@ -6,9 +6,13 @@ data class LoginUiState(
     val username: String = "",
     val password: String = "",
     val isMockModeEnabled: Boolean = true,
+    val isCampusCredentialConsentChecked: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: UiText? = null
 ) {
+    val requiresCampusCredentialConsent: Boolean
+        get() = !isMockModeEnabled
+
     val canSubmit: Boolean
         get() = username.isNotBlank() && password.isNotBlank() && !isLoading
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
@@ -5,7 +5,7 @@ import cn.gdeiassistant.ui.util.UiText
 data class LoginUiState(
     val username: String = "",
     val password: String = "",
-    val isMockModeEnabled: Boolean = true,
+    val isMockModeEnabled: Boolean = false,
     val isCampusCredentialConsentChecked: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: UiText? = null

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
@@ -6,6 +6,7 @@ data class LoginUiState(
     val username: String = "",
     val password: String = "",
     val isMockModeEnabled: Boolean = false,
+    val isMockModeUpdating: Boolean = false,
     val isCampusCredentialConsentChecked: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: UiText? = null
@@ -14,7 +15,7 @@ data class LoginUiState(
         get() = !isMockModeEnabled
 
     val canSubmit: Boolean
-        get() = username.isNotBlank() && password.isNotBlank() && !isLoading
+        get() = username.isNotBlank() && password.isNotBlank() && !isLoading && !isMockModeUpdating
 }
 
 sealed class LoginEvent {

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
@@ -28,7 +28,9 @@ class LoginViewModel @Inject constructor(
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(LoginUiState())
+    private val _uiState = MutableStateFlow(
+        LoginUiState(isMockModeEnabled = SettingsRepository.isMockModeEnabledSync())
+    )
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
     private val _events = MutableSharedFlow<LoginEvent>()

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
@@ -40,10 +40,14 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.isMockModeEnabled.collectLatest { enabled ->
                 _uiState.update { current ->
-                    current.copy(
-                        isMockModeEnabled = enabled,
-                        errorMessage = null
-                    )
+                    if (current.isMockModeEnabled == enabled) {
+                        current
+                    } else {
+                        current.copy(
+                            isMockModeEnabled = enabled,
+                            errorMessage = null
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
@@ -71,11 +71,23 @@ class LoginViewModel @Inject constructor(
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
+        _uiState.update {
+            it.copy(
+                isMockModeEnabled = enabled,
+                isMockModeUpdating = true,
+                errorMessage = null
+            )
+        }
         viewModelScope.launch {
             runCatching { settingsRepository.setMockModeEnabled(enabled) }
+                .onSuccess {
+                    _uiState.update { it.copy(isMockModeUpdating = false) }
+                }
                 .onFailure { error ->
                     _uiState.update {
                         it.copy(
+                            isMockModeEnabled = SettingsRepository.isMockModeEnabledSync(),
+                            isMockModeUpdating = false,
                             errorMessage = UiText.DynamicString(
                                 error.message ?: context.getString(R.string.service_unavailable)
                             )
@@ -88,6 +100,7 @@ class LoginViewModel @Inject constructor(
     fun login() {
         val state = _uiState.value
         if (state.isLoading) return
+        if (state.isMockModeUpdating) return
         if (state.username.isBlank() || state.password.isBlank()) {
             _uiState.update { it.copy(errorMessage = UiText.StringResource(R.string.login_error_empty)) }
             return

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
@@ -1,10 +1,12 @@
 package cn.gdeiassistant.ui.login
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cn.gdeiassistant.R
 import cn.gdeiassistant.data.AuthRepository
 import cn.gdeiassistant.data.SettingsRepository
+import cn.gdeiassistant.model.CampusCredentialConsentMetadata
 import cn.gdeiassistant.ui.util.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -17,7 +19,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import android.content.Context
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,7 +37,12 @@ class LoginViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             settingsRepository.isMockModeEnabled.collectLatest { enabled ->
-                _uiState.update { it.copy(isMockModeEnabled = enabled) }
+                _uiState.update { current ->
+                    current.copy(
+                        isMockModeEnabled = enabled,
+                        errorMessage = null
+                    )
+                }
             }
         }
     }
@@ -47,6 +53,15 @@ class LoginViewModel @Inject constructor(
 
     fun updatePassword(value: String) {
         _uiState.update { it.copy(password = value, errorMessage = null) }
+    }
+
+    fun setCampusCredentialConsentChecked(checked: Boolean) {
+        _uiState.update {
+            it.copy(
+                isCampusCredentialConsentChecked = checked,
+                errorMessage = null
+            )
+        }
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
@@ -71,22 +86,41 @@ class LoginViewModel @Inject constructor(
             _uiState.update { it.copy(errorMessage = UiText.StringResource(R.string.login_error_empty)) }
             return
         }
+        if (state.requiresCampusCredentialConsent && !state.isCampusCredentialConsentChecked) {
+            _uiState.update {
+                it.copy(errorMessage = UiText.StringResource(R.string.login_campus_credential_consent_required))
+            }
+            return
+        }
+
+        val consentMetadata = if (state.requiresCampusCredentialConsent) {
+            CampusCredentialConsentMetadata()
+        } else {
+            null
+        }
+
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
-            authRepository.login(state.username.trim(), state.password)
-                .onSuccess {
-                    _uiState.update { it.copy(isLoading = false) }
-                    _events.emit(LoginEvent.NavigateToHome)
+            authRepository.login(
+                username = state.username.trim(),
+                password = state.password,
+                consentMetadata = consentMetadata
+            ).onSuccess {
+                _uiState.update { it.copy(isLoading = false) }
+                _events.emit(LoginEvent.NavigateToHome)
+            }.onFailure { error ->
+                val message = error.message
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = if (message.isNullOrBlank()) {
+                            UiText.StringResource(R.string.service_unavailable)
+                        } else {
+                            UiText.DynamicString(message)
+                        }
+                    )
                 }
-                .onFailure { e ->
-                    val message = e.message
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            errorMessage = if (message.isNullOrBlank()) UiText.StringResource(R.string.service_unavailable) else UiText.DynamicString(message)
-                        )
-                    }
-                }
+            }
         }
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
@@ -819,14 +819,16 @@ fun ProfileSettingsScreen(navController: NavHostController) {
                     title = stringResource(R.string.profile_settings_mock_title),
                     subtitle = stringResource(R.string.profile_settings_mock_subtitle),
                     checked = state.isMockModeEnabled,
-                    enabled = !state.isBackendTargetChanging,
+                    enabled = !state.isBackendTargetChanging && !state.isCampusCredentialActionRunning,
                     onCheckedChange = viewModel::setMockModeEnabled
                 )
                 HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
                 SettingEnvironmentRow(
                     selectedEnvironment = state.networkEnvironment,
                     baseUrl = state.environmentBaseUrl,
-                    enabled = state.canChangeNetworkEnvironment && !state.isBackendTargetChanging,
+                    enabled = state.canChangeNetworkEnvironment &&
+                        !state.isBackendTargetChanging &&
+                        !state.isCampusCredentialActionRunning,
                     onEnvironmentSelected = viewModel::setNetworkEnvironment
                 )
                 HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
@@ -770,7 +770,7 @@ fun ProfileSettingsScreen(navController: NavHostController) {
             title = stringResource(R.string.profile_settings_campus_credentials_revoke_title),
             message = stringResource(R.string.profile_settings_campus_credentials_revoke_confirmation),
             confirmText = stringResource(R.string.profile_settings_campus_credentials_revoke_action),
-            enabled = !state.isCampusCredentialActionRunning,
+            enabled = !state.isCampusCredentialActionRunning && !state.isBackendTargetChanging,
             onDismiss = { showRevokeConfirmation = false },
             onConfirm = {
                 showRevokeConfirmation = false
@@ -784,7 +784,7 @@ fun ProfileSettingsScreen(navController: NavHostController) {
             title = stringResource(R.string.profile_settings_campus_credentials_delete_title),
             message = stringResource(R.string.profile_settings_campus_credentials_delete_confirmation),
             confirmText = stringResource(R.string.profile_settings_campus_credentials_delete_action),
-            enabled = !state.isCampusCredentialActionRunning,
+            enabled = !state.isCampusCredentialActionRunning && !state.isBackendTargetChanging,
             onDismiss = { showDeleteConfirmation = false },
             onConfirm = {
                 showDeleteConfirmation = false
@@ -799,7 +799,9 @@ fun ProfileSettingsScreen(navController: NavHostController) {
         actions = {
             IconButton(
                 onClick = viewModel::refreshCampusCredentialStatus,
-                enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning
+                enabled = !state.isCampusCredentialLoading &&
+                    !state.isCampusCredentialActionRunning &&
+                    !state.isBackendTargetChanging
             ) {
                 Icon(Icons.Rounded.Refresh, contentDescription = stringResource(R.string.schedule_refresh))
             }
@@ -817,13 +819,14 @@ fun ProfileSettingsScreen(navController: NavHostController) {
                     title = stringResource(R.string.profile_settings_mock_title),
                     subtitle = stringResource(R.string.profile_settings_mock_subtitle),
                     checked = state.isMockModeEnabled,
+                    enabled = !state.isBackendTargetChanging,
                     onCheckedChange = viewModel::setMockModeEnabled
                 )
                 HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
                 SettingEnvironmentRow(
                     selectedEnvironment = state.networkEnvironment,
                     baseUrl = state.environmentBaseUrl,
-                    enabled = state.canChangeNetworkEnvironment,
+                    enabled = state.canChangeNetworkEnvironment && !state.isBackendTargetChanging,
                     onEnvironmentSelected = viewModel::setNetworkEnvironment
                 )
                 HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
@@ -996,7 +999,9 @@ private fun CampusCredentialManagementCard(
         TintButton(
             text = quickAuthActionText,
             onClick = { onToggleQuickAuth(!status.quickAuthEnabled) },
-            enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning,
+            enabled = !state.isCampusCredentialLoading &&
+                !state.isCampusCredentialActionRunning &&
+                !state.isBackendTargetChanging,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(10.dp))
@@ -1010,7 +1015,9 @@ private fun CampusCredentialManagementCard(
             text = stringResource(R.string.profile_settings_campus_credentials_revoke_action),
             icon = Icons.Rounded.WarningAmber,
             onClick = onRevokeClick,
-            enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning,
+            enabled = !state.isCampusCredentialLoading &&
+                !state.isCampusCredentialActionRunning &&
+                !state.isBackendTargetChanging,
             modifier = Modifier.fillMaxWidth(),
             borderColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.28f),
             contentColor = MaterialTheme.colorScheme.tertiary
@@ -1020,7 +1027,9 @@ private fun CampusCredentialManagementCard(
             text = stringResource(R.string.profile_settings_campus_credentials_delete_action),
             icon = Icons.Rounded.DeleteForever,
             onClick = onDeleteClick,
-            enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning,
+            enabled = !state.isCampusCredentialLoading &&
+                !state.isCampusCredentialActionRunning &&
+                !state.isBackendTargetChanging,
             modifier = Modifier.fillMaxWidth(),
             borderColor = MaterialTheme.colorScheme.error.copy(alpha = 0.28f),
             contentColor = MaterialTheme.colorScheme.error
@@ -1331,6 +1340,7 @@ private fun SettingSwitchRow(
     title: String,
     subtitle: String,
     checked: Boolean,
+    enabled: Boolean = true,
     onCheckedChange: (Boolean) -> Unit
 ) {
     Row(
@@ -1350,7 +1360,7 @@ private fun SettingSwitchRow(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
+        Switch(checked = checked, onCheckedChange = onCheckedChange, enabled = enabled)
     }
 }
 

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.WarningAmber
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -47,6 +48,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -752,6 +754,8 @@ fun ProfileSettingsScreen(navController: NavHostController) {
     val context = LocalContext.current
     val viewModel: ProfileSettingsViewModel = hiltViewModel()
     val state by viewModel.state.collectAsStateWithLifecycle()
+    var showRevokeConfirmation by rememberSaveable { mutableStateOf(false) }
+    var showDeleteConfirmation by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(viewModel) {
         viewModel.events.collectLatest { event ->
@@ -761,9 +765,45 @@ fun ProfileSettingsScreen(navController: NavHostController) {
         }
     }
 
+    if (showRevokeConfirmation) {
+        CampusCredentialConfirmationDialog(
+            title = stringResource(R.string.profile_settings_campus_credentials_revoke_title),
+            message = stringResource(R.string.profile_settings_campus_credentials_revoke_confirmation),
+            confirmText = stringResource(R.string.profile_settings_campus_credentials_revoke_action),
+            enabled = !state.isCampusCredentialActionRunning,
+            onDismiss = { showRevokeConfirmation = false },
+            onConfirm = {
+                showRevokeConfirmation = false
+                viewModel.revokeCampusCredentialConsent()
+            }
+        )
+    }
+
+    if (showDeleteConfirmation) {
+        CampusCredentialConfirmationDialog(
+            title = stringResource(R.string.profile_settings_campus_credentials_delete_title),
+            message = stringResource(R.string.profile_settings_campus_credentials_delete_confirmation),
+            confirmText = stringResource(R.string.profile_settings_campus_credentials_delete_action),
+            enabled = !state.isCampusCredentialActionRunning,
+            onDismiss = { showDeleteConfirmation = false },
+            onConfirm = {
+                showDeleteConfirmation = false
+                viewModel.deleteCampusCredential()
+            }
+        )
+    }
+
     LazyScreen(
         title = stringResource(R.string.profile_settings_title),
-        onBack = navController::popBackStack
+        onBack = navController::popBackStack,
+        actions = {
+            IconButton(
+                onClick = viewModel::refreshCampusCredentialStatus,
+                enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning
+            ) {
+                Icon(Icons.Rounded.Refresh, contentDescription = stringResource(R.string.schedule_refresh))
+            }
+        }
     ) {
         item {
             SectionCard(modifier = Modifier.fillMaxWidth()) {
@@ -792,6 +832,14 @@ fun ProfileSettingsScreen(navController: NavHostController) {
                     value = state.appVersion
                 )
             }
+        }
+        item {
+            CampusCredentialManagementCard(
+                state = state,
+                onToggleQuickAuth = viewModel::setQuickAuthEnabled,
+                onRevokeClick = { showRevokeConfirmation = true },
+                onDeleteClick = { showDeleteConfirmation = true }
+            )
         }
         item {
             SectionCard(
@@ -837,6 +885,173 @@ fun ProfileSettingsScreen(navController: NavHostController) {
             }
         }
     }
+}
+
+@Composable
+private fun CampusCredentialManagementCard(
+    state: ProfileSettingsUiState,
+    onToggleQuickAuth: (Boolean) -> Unit,
+    onRevokeClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    val status = state.campusCredentialStatus
+    val quickAuthActionText = if (status.quickAuthEnabled) {
+        stringResource(R.string.profile_settings_campus_credentials_quick_auth_disable_action)
+    } else {
+        stringResource(R.string.profile_settings_campus_credentials_quick_auth_enable_action)
+    }
+    val quickAuthSubtitle = if (status.quickAuthEnabled) {
+        stringResource(R.string.profile_settings_campus_credentials_quick_auth_enabled_subtitle)
+    } else {
+        stringResource(R.string.profile_settings_campus_credentials_quick_auth_disabled_subtitle)
+    }
+
+    SectionCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.profile_settings_campus_credentials_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.profile_settings_campus_credentials_subtitle),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (state.isCampusCredentialLoading) {
+            Text(
+                text = stringResource(R.string.profile_settings_campus_credentials_loading),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        if (!state.campusCredentialError.isNullOrBlank()) {
+            StatusBanner(
+                title = stringResource(R.string.load_failed),
+                body = state.campusCredentialError.orEmpty(),
+                icon = Icons.Rounded.Security,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        SettingInfoRow(
+            title = stringResource(R.string.profile_settings_campus_credentials_consent_status_label),
+            value = stringResource(
+                if (status.hasActiveConsent) {
+                    R.string.profile_settings_campus_credentials_status_authorized
+                } else {
+                    R.string.profile_settings_campus_credentials_status_unauthorized
+                }
+            )
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingInfoRow(
+            title = stringResource(R.string.profile_settings_campus_credentials_saved_label),
+            value = stringResource(
+                if (status.hasSavedCredential) {
+                    R.string.profile_settings_campus_credentials_boolean_yes
+                } else {
+                    R.string.profile_settings_campus_credentials_boolean_no
+                }
+            )
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingInfoRow(
+            title = stringResource(R.string.profile_settings_campus_credentials_quick_auth_label),
+            value = stringResource(
+                if (status.quickAuthEnabled) {
+                    R.string.profile_settings_campus_credentials_quick_auth_on
+                } else {
+                    R.string.profile_settings_campus_credentials_quick_auth_off
+                }
+            )
+        )
+        status.maskedCampusAccount?.takeIf(String::isNotBlank)?.let { maskedAccount ->
+            Spacer(modifier = Modifier.height(10.dp))
+            SettingInfoRow(
+                title = stringResource(R.string.profile_settings_campus_credentials_account_label),
+                value = maskedAccount
+            )
+        }
+        status.consentedAt?.takeIf(String::isNotBlank)?.let { consentedAt ->
+            Spacer(modifier = Modifier.height(10.dp))
+            SettingInfoRow(
+                title = stringResource(R.string.profile_settings_campus_credentials_consented_at_label),
+                value = consentedAt
+            )
+        }
+        status.revokedAt?.takeIf(String::isNotBlank)?.let { revokedAt ->
+            Spacer(modifier = Modifier.height(10.dp))
+            SettingInfoRow(
+                title = stringResource(R.string.profile_settings_campus_credentials_revoked_at_label),
+                value = revokedAt
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        TintButton(
+            text = quickAuthActionText,
+            onClick = { onToggleQuickAuth(!status.quickAuthEnabled) },
+            enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = quickAuthSubtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        GhostButton(
+            text = stringResource(R.string.profile_settings_campus_credentials_revoke_action),
+            icon = Icons.Rounded.WarningAmber,
+            onClick = onRevokeClick,
+            enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning,
+            modifier = Modifier.fillMaxWidth(),
+            borderColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.28f),
+            contentColor = MaterialTheme.colorScheme.tertiary
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        GhostButton(
+            text = stringResource(R.string.profile_settings_campus_credentials_delete_action),
+            icon = Icons.Rounded.DeleteForever,
+            onClick = onDeleteClick,
+            enabled = !state.isCampusCredentialLoading && !state.isCampusCredentialActionRunning,
+            modifier = Modifier.fillMaxWidth(),
+            borderColor = MaterialTheme.colorScheme.error.copy(alpha = 0.28f),
+            contentColor = MaterialTheme.colorScheme.error
+        )
+    }
+}
+
+@Composable
+private fun CampusCredentialConfirmationDialog(
+    title: String,
+    message: String,
+    confirmText: String,
+    enabled: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = title) },
+        text = { Text(text = message) },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = enabled) {
+                Text(text = confirmText)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = enabled) {
+                Text(text = stringResource(R.string.profile_info_cancel))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
@@ -614,6 +614,7 @@ data class ProfileSettingsUiState(
     val campusCredentialStatus: CampusCredentialStatus = CampusCredentialStatus(),
     val isCampusCredentialLoading: Boolean = true,
     val isCampusCredentialActionRunning: Boolean = false,
+    val isBackendTargetChanging: Boolean = false,
     val campusCredentialError: String? = null
 )
 
@@ -628,7 +629,14 @@ class ProfileSettingsViewModel @Inject constructor(
     private val campusCredentialRepository: CampusCredentialRepository
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(ProfileSettingsUiState())
+    private val initialNetworkEnvironment = SettingsRepository.currentNetworkEnvironmentSync()
+    private val _state = MutableStateFlow(
+        ProfileSettingsUiState(
+            isMockModeEnabled = SettingsRepository.isMockModeEnabledSync(),
+            networkEnvironment = initialNetworkEnvironment,
+            environmentBaseUrl = initialNetworkEnvironment.baseUrl
+        )
+    )
     val state: StateFlow<ProfileSettingsUiState> = _state.asStateFlow()
 
     private val _events = MutableSharedFlow<ProfileSettingsEvent>()
@@ -636,17 +644,35 @@ class ProfileSettingsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            var hasObservedMockMode = false
             settingsRepository.isMockModeEnabled.collectLatest { enabled ->
+                val previous = _state.value.isMockModeEnabled
+                val shouldRefresh = hasObservedMockMode &&
+                    previous != enabled &&
+                    !_state.value.isBackendTargetChanging
                 _state.update { it.copy(isMockModeEnabled = enabled) }
+                hasObservedMockMode = true
+                if (shouldRefresh) {
+                    refreshCampusCredentialStatus()
+                }
             }
         }
         viewModelScope.launch {
+            var hasObservedNetworkEnvironment = false
             settingsRepository.networkEnvironment.collectLatest { environment ->
+                val previous = _state.value.networkEnvironment
+                val shouldRefresh = hasObservedNetworkEnvironment &&
+                    previous != environment &&
+                    !_state.value.isBackendTargetChanging
                 _state.update {
                     it.copy(
                         networkEnvironment = environment,
                         environmentBaseUrl = environment.baseUrl
                     )
+                }
+                hasObservedNetworkEnvironment = true
+                if (shouldRefresh) {
+                    refreshCampusCredentialStatus()
                 }
             }
         }
@@ -654,9 +680,26 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
+        if (_state.value.isBackendTargetChanging) return
+        _state.update {
+            it.copy(
+                isMockModeEnabled = enabled,
+                isBackendTargetChanging = true,
+                campusCredentialError = null
+            )
+        }
         viewModelScope.launch {
             runCatching { settingsRepository.setMockModeEnabled(enabled) }
+                .onSuccess {
+                    refreshCampusCredentialStatus()
+                }
                 .onFailure { error ->
+                    _state.update {
+                        it.copy(
+                            isMockModeEnabled = SettingsRepository.isMockModeEnabledSync(),
+                            isBackendTargetChanging = false
+                        )
+                    }
                     _events.emit(
                         ProfileSettingsEvent.ShowMessage(
                             error.message ?: context.getString(R.string.profile_settings_toggle_failed)
@@ -667,9 +710,29 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun setNetworkEnvironment(environment: NetworkEnvironment) {
+        if (_state.value.isBackendTargetChanging) return
+        _state.update {
+            it.copy(
+                networkEnvironment = environment,
+                environmentBaseUrl = environment.baseUrl,
+                isBackendTargetChanging = true,
+                campusCredentialError = null
+            )
+        }
         viewModelScope.launch {
             runCatching { settingsRepository.setNetworkEnvironment(environment) }
+                .onSuccess {
+                    refreshCampusCredentialStatus()
+                }
                 .onFailure { error ->
+                    val currentEnvironment = SettingsRepository.currentNetworkEnvironmentSync()
+                    _state.update {
+                        it.copy(
+                            networkEnvironment = currentEnvironment,
+                            environmentBaseUrl = currentEnvironment.baseUrl,
+                            isBackendTargetChanging = false
+                        )
+                    }
                     _events.emit(
                         ProfileSettingsEvent.ShowMessage(
                             error.message ?: context.getString(R.string.profile_settings_toggle_failed)
@@ -681,7 +744,13 @@ class ProfileSettingsViewModel @Inject constructor(
 
     fun refreshCampusCredentialStatus() {
         viewModelScope.launch {
-            _state.update { it.copy(isCampusCredentialLoading = true, campusCredentialError = null) }
+            _state.update {
+                it.copy(
+                    isCampusCredentialLoading = true,
+                    isBackendTargetChanging = false,
+                    campusCredentialError = null
+                )
+            }
             campusCredentialRepository.getCampusCredentialStatus()
                 .onSuccess { status ->
                     _state.update {
@@ -734,7 +803,7 @@ class ProfileSettingsViewModel @Inject constructor(
         action: suspend () -> Result<CampusCredentialStatus>,
         successMessage: String
     ) {
-        if (_state.value.isCampusCredentialActionRunning) return
+        if (_state.value.isCampusCredentialActionRunning || _state.value.isBackendTargetChanging) return
         viewModelScope.launch {
             _state.update {
                 it.copy(

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import cn.gdeiassistant.R
 import cn.gdeiassistant.data.CampusCredentialRepository
 import cn.gdeiassistant.data.ProfileRepository
+import cn.gdeiassistant.data.SessionManager
 import cn.gdeiassistant.data.mapper.PhoneAttributionCatalog
 import cn.gdeiassistant.data.mapper.ProfileDisplayMapper
 import cn.gdeiassistant.data.SettingsRepository

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
@@ -647,25 +647,20 @@ class ProfileSettingsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            var hasObservedMockMode = false
             settingsRepository.isMockModeEnabled.collectLatest { enabled ->
                 val previous = _state.value.isMockModeEnabled
-                val shouldRefresh = hasObservedMockMode &&
-                    previous != enabled &&
+                val shouldRefresh = previous != enabled &&
                     !_state.value.isBackendTargetChanging
                 _state.update { it.copy(isMockModeEnabled = enabled) }
-                hasObservedMockMode = true
                 if (shouldRefresh) {
                     refreshCampusCredentialStatus()
                 }
             }
         }
         viewModelScope.launch {
-            var hasObservedNetworkEnvironment = false
             settingsRepository.networkEnvironment.collectLatest { environment ->
                 val previous = _state.value.networkEnvironment
-                val shouldRefresh = hasObservedNetworkEnvironment &&
-                    previous != environment &&
+                val shouldRefresh = previous != environment &&
                     !_state.value.isBackendTargetChanging
                 _state.update {
                     it.copy(
@@ -673,7 +668,6 @@ class ProfileSettingsViewModel @Inject constructor(
                         environmentBaseUrl = environment.baseUrl
                     )
                 }
-                hasObservedNetworkEnvironment = true
                 if (shouldRefresh) {
                     refreshCampusCredentialStatus()
                 }

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
@@ -21,6 +21,7 @@ import cn.gdeiassistant.model.UserDataExportState
 import cn.gdeiassistant.network.NetworkEnvironment
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -641,6 +642,8 @@ class ProfileSettingsViewModel @Inject constructor(
 
     private val _events = MutableSharedFlow<ProfileSettingsEvent>()
     val events: SharedFlow<ProfileSettingsEvent> = _events.asSharedFlow()
+    private var campusCredentialRefreshJob: Job? = null
+    private var campusCredentialRefreshSequence = 0
 
     init {
         viewModelScope.launch {
@@ -680,7 +683,7 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
-        if (_state.value.isBackendTargetChanging) return
+        if (_state.value.isBackendTargetChanging || _state.value.isCampusCredentialActionRunning) return
         _state.update {
             it.copy(
                 isMockModeEnabled = enabled,
@@ -710,7 +713,7 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun setNetworkEnvironment(environment: NetworkEnvironment) {
-        if (_state.value.isBackendTargetChanging) return
+        if (_state.value.isBackendTargetChanging || _state.value.isCampusCredentialActionRunning) return
         _state.update {
             it.copy(
                 networkEnvironment = environment,
@@ -743,28 +746,33 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun refreshCampusCredentialStatus() {
-        viewModelScope.launch {
+        val refreshSequence = ++campusCredentialRefreshSequence
+        campusCredentialRefreshJob?.cancel()
+        campusCredentialRefreshJob = viewModelScope.launch {
             _state.update {
                 it.copy(
                     isCampusCredentialLoading = true,
-                    isBackendTargetChanging = false,
                     campusCredentialError = null
                 )
             }
             campusCredentialRepository.getCampusCredentialStatus()
                 .onSuccess { status ->
+                    if (refreshSequence != campusCredentialRefreshSequence) return@launch
                     _state.update {
                         it.copy(
                             campusCredentialStatus = status,
                             isCampusCredentialLoading = false,
+                            isBackendTargetChanging = false,
                             campusCredentialError = null
                         )
                     }
                 }
                 .onFailure { error ->
+                    if (refreshSequence != campusCredentialRefreshSequence) return@launch
                     _state.update {
                         it.copy(
                             isCampusCredentialLoading = false,
+                            isBackendTargetChanging = false,
                             campusCredentialError = error.message
                         )
                     }
@@ -804,13 +812,13 @@ class ProfileSettingsViewModel @Inject constructor(
         successMessage: String
     ) {
         if (_state.value.isCampusCredentialActionRunning || _state.value.isBackendTargetChanging) return
+        _state.update {
+            it.copy(
+                isCampusCredentialActionRunning = true,
+                campusCredentialError = null
+            )
+        }
         viewModelScope.launch {
-            _state.update {
-                it.copy(
-                    isCampusCredentialActionRunning = true,
-                    campusCredentialError = null
-                )
-            }
             action()
                 .onSuccess { status ->
                     _state.update {

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
@@ -5,11 +5,12 @@ import cn.gdeiassistant.BuildConfig
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cn.gdeiassistant.R
+import cn.gdeiassistant.data.CampusCredentialRepository
 import cn.gdeiassistant.data.ProfileRepository
-import cn.gdeiassistant.data.SessionManager
 import cn.gdeiassistant.data.mapper.PhoneAttributionCatalog
 import cn.gdeiassistant.data.mapper.ProfileDisplayMapper
 import cn.gdeiassistant.data.SettingsRepository
+import cn.gdeiassistant.model.CampusCredentialStatus
 import cn.gdeiassistant.model.ContactBindingStatus
 import cn.gdeiassistant.model.FeedbackSubmission
 import cn.gdeiassistant.model.LoginRecordItem
@@ -608,7 +609,11 @@ data class ProfileSettingsUiState(
     val networkEnvironment: NetworkEnvironment = NetworkEnvironment.default(),
     val environmentBaseUrl: String = NetworkEnvironment.default().baseUrl,
     val canChangeNetworkEnvironment: Boolean = BuildConfig.DEBUG,
-    val appVersion: String = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+    val appVersion: String = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+    val campusCredentialStatus: CampusCredentialStatus = CampusCredentialStatus(),
+    val isCampusCredentialLoading: Boolean = true,
+    val isCampusCredentialActionRunning: Boolean = false,
+    val campusCredentialError: String? = null
 )
 
 sealed interface ProfileSettingsEvent {
@@ -618,7 +623,8 @@ sealed interface ProfileSettingsEvent {
 @HiltViewModel
 class ProfileSettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val campusCredentialRepository: CampusCredentialRepository
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ProfileSettingsUiState())
@@ -643,6 +649,7 @@ class ProfileSettingsViewModel @Inject constructor(
                 }
             }
         }
+        refreshCampusCredentialStatus()
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
@@ -665,6 +672,92 @@ class ProfileSettingsViewModel @Inject constructor(
                     _events.emit(
                         ProfileSettingsEvent.ShowMessage(
                             error.message ?: context.getString(R.string.profile_settings_toggle_failed)
+                        )
+                    )
+                }
+        }
+    }
+
+    fun refreshCampusCredentialStatus() {
+        viewModelScope.launch {
+            _state.update { it.copy(isCampusCredentialLoading = true, campusCredentialError = null) }
+            campusCredentialRepository.getCampusCredentialStatus()
+                .onSuccess { status ->
+                    _state.update {
+                        it.copy(
+                            campusCredentialStatus = status,
+                            isCampusCredentialLoading = false,
+                            campusCredentialError = null
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _state.update {
+                        it.copy(
+                            isCampusCredentialLoading = false,
+                            campusCredentialError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    fun revokeCampusCredentialConsent() {
+        performCampusCredentialAction(
+            action = { campusCredentialRepository.revokeCampusCredentialConsent() },
+            successMessage = context.getString(R.string.profile_settings_campus_credentials_revoke_success)
+        )
+    }
+
+    fun deleteCampusCredential() {
+        performCampusCredentialAction(
+            action = { campusCredentialRepository.deleteCampusCredential() },
+            successMessage = context.getString(R.string.profile_settings_campus_credentials_delete_success)
+        )
+    }
+
+    fun setQuickAuthEnabled(enabled: Boolean) {
+        performCampusCredentialAction(
+            action = { campusCredentialRepository.setQuickAuthEnabled(enabled) },
+            successMessage = context.getString(
+                if (enabled) {
+                    R.string.profile_settings_campus_credentials_quick_auth_enabled_success
+                } else {
+                    R.string.profile_settings_campus_credentials_quick_auth_disabled_success
+                }
+            )
+        )
+    }
+
+    private fun performCampusCredentialAction(
+        action: suspend () -> Result<CampusCredentialStatus>,
+        successMessage: String
+    ) {
+        if (_state.value.isCampusCredentialActionRunning) return
+        viewModelScope.launch {
+            _state.update {
+                it.copy(
+                    isCampusCredentialActionRunning = true,
+                    campusCredentialError = null
+                )
+            }
+            action()
+                .onSuccess { status ->
+                    _state.update {
+                        it.copy(
+                            campusCredentialStatus = status,
+                            isCampusCredentialLoading = false,
+                            isCampusCredentialActionRunning = false,
+                            campusCredentialError = null
+                        )
+                    }
+                    _events.emit(ProfileSettingsEvent.ShowMessage(successMessage))
+                }
+                .onFailure { error ->
+                    _state.update { it.copy(isCampusCredentialActionRunning = false) }
+                    _events.emit(
+                        ProfileSettingsEvent.ShowMessage(
+                            error.message ?: context.getString(R.string.profile_settings_campus_credentials_action_failed)
                         )
                     )
                 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -39,6 +39,9 @@
     <string name="login_mock_enabled_subtitle">This login will use local demo data</string>
     <string name="login_mock_disabled_subtitle">Turning off will use the current service environment</string>
     <string name="login_mock_account_hint">Local demo login is only for UI previews and demos</string>
+    <string name="login_campus_credential_consent_label">I have read and separately agree that the platform may process my campus account credentials within the necessary scope for campus authentication, quick authentication, campus data queries, and required session synchronization with school systems.</string>
+    <string name="login_campus_credential_consent_note">You can manage consent, delete saved credentials, or turn quick authentication on or off later in Settings.</string>
+    <string name="login_campus_credential_consent_required">Please agree to campus credential consent before logging in</string>
     <string name="privacy_policy">Privacy Policy</string>
 
     <!-- 2.0 General -->
@@ -1391,6 +1394,36 @@
     <string name="profile_settings_environment_endpoint_title">Current Endpoint</string>
     <string name="profile_settings_version_title">Version</string>
     <string name="profile_settings_toggle_failed">Failed to toggle setting</string>
+    <string name="profile_settings_campus_credentials_title">Campus Credential Management</string>
+    <string name="profile_settings_campus_credentials_subtitle">Review consent status, saved credentials, and quick authentication, and revoke consent or delete saved credentials at any time.</string>
+    <string name="profile_settings_campus_credentials_loading">Syncing campus credential status…</string>
+    <string name="profile_settings_campus_credentials_consent_status_label">Consent status</string>
+    <string name="profile_settings_campus_credentials_saved_label">Saved credential</string>
+    <string name="profile_settings_campus_credentials_quick_auth_label">Quick authentication</string>
+    <string name="profile_settings_campus_credentials_account_label">Campus account</string>
+    <string name="profile_settings_campus_credentials_consented_at_label">Consented at</string>
+    <string name="profile_settings_campus_credentials_revoked_at_label">Revoked at</string>
+    <string name="profile_settings_campus_credentials_status_authorized">Authorized</string>
+    <string name="profile_settings_campus_credentials_status_unauthorized">Not authorized</string>
+    <string name="profile_settings_campus_credentials_boolean_yes">Yes</string>
+    <string name="profile_settings_campus_credentials_boolean_no">No</string>
+    <string name="profile_settings_campus_credentials_quick_auth_on">Enabled</string>
+    <string name="profile_settings_campus_credentials_quick_auth_off">Disabled</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enable_action">Enable Quick Authentication</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disable_action">Disable Quick Authentication</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_subtitle">Turning it off stops quick authentication or session synchronization based on saved credentials.</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_subtitle">Active consent and a saved credential are required before enabling it. The backend will return a reason if the request is rejected.</string>
+    <string name="profile_settings_campus_credentials_revoke_title">Revoke Campus Credential Consent</string>
+    <string name="profile_settings_campus_credentials_revoke_action">Revoke Consent</string>
+    <string name="profile_settings_campus_credentials_revoke_confirmation">Revoking consent stops future quick authentication or session synchronization based on saved campus credentials. Depending on backend safety settings, saved credentials may also be deleted.</string>
+    <string name="profile_settings_campus_credentials_delete_title">Delete Saved Campus Credential</string>
+    <string name="profile_settings_campus_credentials_delete_action">Delete Saved Credential</string>
+    <string name="profile_settings_campus_credentials_delete_confirmation">After deletion, schedule, grades, campus card, library, and similar queries may require logging in or authorizing again.</string>
+    <string name="profile_settings_campus_credentials_revoke_success">Consent revoked. The platform will stop quick authentication or session synchronization based on saved credentials.</string>
+    <string name="profile_settings_campus_credentials_delete_success">Saved campus credentials deleted. Schedule, grades, campus card, library, and similar queries may require logging in or authorizing again.</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_success">Quick authentication enabled</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_success">Quick authentication disabled</string>
+    <string name="profile_settings_campus_credentials_action_failed">Campus credential action failed. Please try again later.</string>
     <string name="profile_delete_title">Delete Account</string>
     <string name="profile_delete_entry_subtitle">Submit account deletion request and clear local session</string>
     <string name="profile_delete_warning_title">This action cannot be undone</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -39,6 +39,9 @@
     <string name="login_mock_enabled_subtitle">現在のログインはローカルのデモデータを使用します</string>
     <string name="login_mock_disabled_subtitle">オフにすると現在のサービス環境を使用します</string>
     <string name="login_mock_account_hint">ローカルデモログインは画面確認とデモ表示専用です</string>
+    <string name="login_campus_credential_consent_label">私は、キャンパス認証、クイック認証、学内データ照会、学校システムとの必要なセッション同期のために、必要な範囲でプラットフォームが私のキャンパスアカウント資格情報を処理することに、内容を読み個別に同意します。</string>
+    <string name="login_campus_credential_consent_note">後で設定から同意状況の確認、同意の撤回、保存済み資格情報の削除、クイック認証のオン/オフを行えます。</string>
+    <string name="login_campus_credential_consent_required">ログイン前にキャンパス資格情報への同意が必要です</string>
     <string name="privacy_policy">プライバシーポリシー</string>
 
     <!-- 2.0 共通 -->
@@ -1392,6 +1395,36 @@
     <string name="profile_settings_environment_endpoint_title">現在のサービスアドレス</string>
     <string name="profile_settings_version_title">現在のバージョン</string>
     <string name="profile_settings_toggle_failed">設定の切り替えに失敗しました</string>
+    <string name="profile_settings_campus_credentials_title">キャンパス資格情報の管理</string>
+    <string name="profile_settings_campus_credentials_subtitle">同意状況、保存済み資格情報、クイック認証を確認し、いつでも同意撤回や保存済み資格情報の削除を行えます。</string>
+    <string name="profile_settings_campus_credentials_loading">キャンパス資格情報の状態を同期しています…</string>
+    <string name="profile_settings_campus_credentials_consent_status_label">同意状況</string>
+    <string name="profile_settings_campus_credentials_saved_label">保存済み資格情報</string>
+    <string name="profile_settings_campus_credentials_quick_auth_label">クイック認証</string>
+    <string name="profile_settings_campus_credentials_account_label">キャンパスアカウント</string>
+    <string name="profile_settings_campus_credentials_consented_at_label">同意日時</string>
+    <string name="profile_settings_campus_credentials_revoked_at_label">撤回日時</string>
+    <string name="profile_settings_campus_credentials_status_authorized">同意済み</string>
+    <string name="profile_settings_campus_credentials_status_unauthorized">未同意</string>
+    <string name="profile_settings_campus_credentials_boolean_yes">はい</string>
+    <string name="profile_settings_campus_credentials_boolean_no">いいえ</string>
+    <string name="profile_settings_campus_credentials_quick_auth_on">有効</string>
+    <string name="profile_settings_campus_credentials_quick_auth_off">無効</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enable_action">クイック認証を有効にする</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disable_action">クイック認証を無効にする</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_subtitle">無効にすると、保存済み資格情報に基づくクイック認証やセッション同期が停止します。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_subtitle">有効にするには、有効な同意と保存済み資格情報が必要です。条件を満たさない場合は、バックエンドが失敗理由を返します。</string>
+    <string name="profile_settings_campus_credentials_revoke_title">キャンパス資格情報の同意を撤回</string>
+    <string name="profile_settings_campus_credentials_revoke_action">同意を撤回</string>
+    <string name="profile_settings_campus_credentials_revoke_confirmation">同意を撤回すると、保存済みキャンパス資格情報に基づくクイック認証やセッション同期が停止します。サーバー側の安全優先設定によっては、保存済み資格情報も削除される場合があります。</string>
+    <string name="profile_settings_campus_credentials_delete_title">保存済みキャンパス資格情報を削除</string>
+    <string name="profile_settings_campus_credentials_delete_action">保存済み資格情報を削除</string>
+    <string name="profile_settings_campus_credentials_delete_confirmation">削除後は、時間割、成績、キャンパスカード、図書館などの機能で再ログインまたは再認可が必要になる場合があります。</string>
+    <string name="profile_settings_campus_credentials_revoke_success">同意を撤回しました。保存済み資格情報に基づくクイック認証やセッション同期は停止されます。</string>
+    <string name="profile_settings_campus_credentials_delete_success">保存済みキャンパス資格情報を削除しました。時間割、成績、キャンパスカード、図書館などの機能で再ログインまたは再認可が必要になる場合があります。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_success">クイック認証を有効にしました</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_success">クイック認証を無効にしました</string>
+    <string name="profile_settings_campus_credentials_action_failed">キャンパス資格情報の操作に失敗しました。後でもう一度お試しください。</string>
     <string name="profile_delete_title">アカウント削除</string>
     <string name="profile_delete_entry_subtitle">アカウント削除申請を送信し、ローカルのログイン情報をクリアします</string>
     <string name="profile_delete_warning_title">この操作は元に戻せません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -39,6 +39,9 @@
     <string name="login_mock_enabled_subtitle">현재 로그인은 로컬 데모 데이터를 사용합니다</string>
     <string name="login_mock_disabled_subtitle">비활성화하면 현재 서비스 환경을 사용합니다</string>
     <string name="login_mock_account_hint">로컬 데모 로그인은 화면 검증과 데모 표시 전용입니다</string>
+    <string name="login_campus_credential_consent_label">저는 캠퍼스 인증, 빠른 인증, 교내 데이터 조회 및 학교 시스템과의 필요한 세션 동기화를 위해 플랫폼이 필요한 범위 내에서 제 캠퍼스 계정 자격 정보를 처리하는 데 대해 읽고 별도로 동의합니다.</string>
+    <string name="login_campus_credential_consent_note">나중에 설정에서 동의 상태 확인, 동의 철회, 저장된 자격 정보 삭제, 빠른 인증 켜기/끄기를 할 수 있습니다.</string>
+    <string name="login_campus_credential_consent_required">로그인하기 전에 캠퍼스 자격 정보 동의가 필요합니다</string>
     <string name="privacy_policy">개인정보 처리방침</string>
 
     <!-- 2.0 공통 -->
@@ -1392,6 +1395,36 @@
     <string name="profile_settings_environment_endpoint_title">현재 서비스 주소</string>
     <string name="profile_settings_version_title">현재 버전</string>
     <string name="profile_settings_toggle_failed">설정 전환 실패</string>
+    <string name="profile_settings_campus_credentials_title">캠퍼스 자격 정보 관리</string>
+    <string name="profile_settings_campus_credentials_subtitle">동의 상태, 저장된 자격 정보, 빠른 인증을 확인하고 언제든지 동의를 철회하거나 저장된 자격 정보를 삭제할 수 있습니다.</string>
+    <string name="profile_settings_campus_credentials_loading">캠퍼스 자격 정보 상태를 동기화하는 중…</string>
+    <string name="profile_settings_campus_credentials_consent_status_label">동의 상태</string>
+    <string name="profile_settings_campus_credentials_saved_label">저장된 자격 정보</string>
+    <string name="profile_settings_campus_credentials_quick_auth_label">빠른 인증</string>
+    <string name="profile_settings_campus_credentials_account_label">캠퍼스 계정</string>
+    <string name="profile_settings_campus_credentials_consented_at_label">동의 시각</string>
+    <string name="profile_settings_campus_credentials_revoked_at_label">철회 시각</string>
+    <string name="profile_settings_campus_credentials_status_authorized">동의됨</string>
+    <string name="profile_settings_campus_credentials_status_unauthorized">동의 안 됨</string>
+    <string name="profile_settings_campus_credentials_boolean_yes">예</string>
+    <string name="profile_settings_campus_credentials_boolean_no">아니오</string>
+    <string name="profile_settings_campus_credentials_quick_auth_on">켜짐</string>
+    <string name="profile_settings_campus_credentials_quick_auth_off">꺼짐</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enable_action">빠른 인증 켜기</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disable_action">빠른 인증 끄기</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_subtitle">끄면 저장된 자격 정보 기반의 빠른 인증 및 세션 동기화가 중지됩니다.</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_subtitle">켜려면 유효한 동의와 저장된 자격 정보가 필요합니다. 조건이 맞지 않으면 백엔드가 실패 사유를 반환합니다.</string>
+    <string name="profile_settings_campus_credentials_revoke_title">캠퍼스 자격 정보 동의 철회</string>
+    <string name="profile_settings_campus_credentials_revoke_action">동의 철회</string>
+    <string name="profile_settings_campus_credentials_revoke_confirmation">동의를 철회하면 저장된 캠퍼스 자격 정보 기반의 빠른 인증 및 세션 동기화가 중지됩니다. 서버의 안전 우선 설정에 따라 저장된 자격 정보도 함께 삭제될 수 있습니다.</string>
+    <string name="profile_settings_campus_credentials_delete_title">저장된 캠퍼스 자격 정보 삭제</string>
+    <string name="profile_settings_campus_credentials_delete_action">저장된 자격 정보 삭제</string>
+    <string name="profile_settings_campus_credentials_delete_confirmation">삭제 후에는 시간표, 성적, 캠퍼스 카드, 도서관 등의 기능을 다시 로그인하거나 재인증해야 할 수 있습니다.</string>
+    <string name="profile_settings_campus_credentials_revoke_success">동의가 철회되었습니다. 저장된 자격 정보 기반의 빠른 인증 및 세션 동기화가 중지됩니다.</string>
+    <string name="profile_settings_campus_credentials_delete_success">저장된 캠퍼스 자격 정보를 삭제했습니다. 시간표, 성적, 캠퍼스 카드, 도서관 등의 기능을 다시 로그인하거나 재인증해야 할 수 있습니다.</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_success">빠른 인증이 켜졌습니다</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_success">빠른 인증이 꺼졌습니다</string>
+    <string name="profile_settings_campus_credentials_action_failed">캠퍼스 자격 정보 작업에 실패했습니다. 잠시 후 다시 시도해 주세요.</string>
     <string name="profile_delete_title">계정 탈퇴</string>
     <string name="profile_delete_entry_subtitle">계정 탈퇴 신청 제출 및 로컬 로그인 상태 정리</string>
     <string name="profile_delete_warning_title">이 작업은 되돌릴 수 없습니다</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -38,6 +38,9 @@
     <string name="login_mock_enabled_subtitle">當前登錄將使用本地示例數據</string>
     <string name="login_mock_disabled_subtitle">關閉後將使用當前服務環境</string>
     <string name="login_mock_account_hint">本地示例登錄僅用於界面驗證和演示展示</string>
+    <string name="login_campus_credential_consent_label">我已閱讀並單獨同意平台在必要範圍內處理我的校園賬號憑證，用於校園身份認證、快速認證、校園數據查詢及與學校系統的必要會話同步。</string>
+    <string name="login_campus_credential_consent_note">你可以在設置中查看授權狀態、撤回授權、刪除已保存憑證或關閉快速認證。</string>
+    <string name="login_campus_credential_consent_required">請先單獨同意校園憑證授權後再登錄</string>
     <string name="privacy_policy">私隱政策</string>
 
     <!-- 2.0 通用 -->
@@ -1391,6 +1394,36 @@
     <string name="profile_settings_environment_endpoint_title">當前服務地址</string>
     <string name="profile_settings_version_title">當前版本</string>
     <string name="profile_settings_toggle_failed">切換設置失敗</string>
+    <string name="profile_settings_campus_credentials_title">校園憑證管理</string>
+    <string name="profile_settings_campus_credentials_subtitle">查看授權狀態、已保存憑證和快速認證，並可隨時撤回授權或刪除已保存憑證。</string>
+    <string name="profile_settings_campus_credentials_loading">正在同步校園憑證狀態…</string>
+    <string name="profile_settings_campus_credentials_consent_status_label">授權狀態</string>
+    <string name="profile_settings_campus_credentials_saved_label">已保存憑證</string>
+    <string name="profile_settings_campus_credentials_quick_auth_label">快速認證</string>
+    <string name="profile_settings_campus_credentials_account_label">校園賬號</string>
+    <string name="profile_settings_campus_credentials_consented_at_label">授權時間</string>
+    <string name="profile_settings_campus_credentials_revoked_at_label">撤回時間</string>
+    <string name="profile_settings_campus_credentials_status_authorized">已授權</string>
+    <string name="profile_settings_campus_credentials_status_unauthorized">未授權</string>
+    <string name="profile_settings_campus_credentials_boolean_yes">是</string>
+    <string name="profile_settings_campus_credentials_boolean_no">否</string>
+    <string name="profile_settings_campus_credentials_quick_auth_on">已開啟</string>
+    <string name="profile_settings_campus_credentials_quick_auth_off">已關閉</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enable_action">開啟快速認證</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disable_action">關閉快速認證</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_subtitle">關閉後，平台將停止基於已保存憑證進行快速認證或會話同步。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_subtitle">開啟前需要有效授權和已保存憑證；如條件不滿足，服務端會返回失敗原因。</string>
+    <string name="profile_settings_campus_credentials_revoke_title">撤回校園賬號憑證授權</string>
+    <string name="profile_settings_campus_credentials_revoke_action">撤回授權</string>
+    <string name="profile_settings_campus_credentials_revoke_confirmation">撤回授權將停止後續基於已保存校園憑證的快速認證或會話同步；如服務端配置為安全優先處理，已保存憑證也可能被同步刪除。</string>
+    <string name="profile_settings_campus_credentials_delete_title">刪除已保存的校園憑證</string>
+    <string name="profile_settings_campus_credentials_delete_action">刪除已保存憑證</string>
+    <string name="profile_settings_campus_credentials_delete_confirmation">刪除後，課表、成績、校園卡、圖書館等查詢可能需要重新登錄或重新授權。</string>
+    <string name="profile_settings_campus_credentials_revoke_success">授權已撤回，平台將停止基於已保存憑證進行快速認證或會話同步。</string>
+    <string name="profile_settings_campus_credentials_delete_success">已刪除保存的校園憑證，後續課表、成績、校園卡、圖書館等查詢可能需要重新登錄或重新授權。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_success">快速認證已開啟</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_success">快速認證已關閉</string>
+    <string name="profile_settings_campus_credentials_action_failed">校園憑證操作失敗，請稍後再試</string>
     <string name="profile_delete_title">註銷賬號</string>
     <string name="profile_delete_entry_subtitle">提交賬號註銷申請並清理本地登錄態</string>
     <string name="profile_delete_warning_title">此操作不可恢復</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -38,6 +38,9 @@
     <string name="login_mock_enabled_subtitle">當前登入將使用本機示例資料</string>
     <string name="login_mock_disabled_subtitle">關閉後將使用當前服務環境</string>
     <string name="login_mock_account_hint">本機示例登入僅用於介面驗證和展示示範</string>
+    <string name="login_campus_credential_consent_label">我已閱讀並單獨同意平台在必要範圍內處理我的校園帳號憑證，用於校園身分驗證、快速認證、校園資料查詢及與學校系統的必要會話同步。</string>
+    <string name="login_campus_credential_consent_note">你可以在設定中查看授權狀態、撤回授權、刪除已保存憑證或關閉快速認證。</string>
+    <string name="login_campus_credential_consent_required">請先單獨同意校園憑證授權後再登入</string>
     <string name="privacy_policy">隱私權政策</string>
 
     <!-- 2.0 通用 -->
@@ -1391,6 +1394,36 @@
     <string name="profile_settings_environment_endpoint_title">當前服務位址</string>
     <string name="profile_settings_version_title">當前版本</string>
     <string name="profile_settings_toggle_failed">切換設定失敗</string>
+    <string name="profile_settings_campus_credentials_title">校園憑證管理</string>
+    <string name="profile_settings_campus_credentials_subtitle">查看授權狀態、已保存憑證和快速認證，並可隨時撤回授權或刪除已保存憑證。</string>
+    <string name="profile_settings_campus_credentials_loading">正在同步校園憑證狀態…</string>
+    <string name="profile_settings_campus_credentials_consent_status_label">授權狀態</string>
+    <string name="profile_settings_campus_credentials_saved_label">已保存憑證</string>
+    <string name="profile_settings_campus_credentials_quick_auth_label">快速認證</string>
+    <string name="profile_settings_campus_credentials_account_label">校園帳號</string>
+    <string name="profile_settings_campus_credentials_consented_at_label">授權時間</string>
+    <string name="profile_settings_campus_credentials_revoked_at_label">撤回時間</string>
+    <string name="profile_settings_campus_credentials_status_authorized">已授權</string>
+    <string name="profile_settings_campus_credentials_status_unauthorized">未授權</string>
+    <string name="profile_settings_campus_credentials_boolean_yes">是</string>
+    <string name="profile_settings_campus_credentials_boolean_no">否</string>
+    <string name="profile_settings_campus_credentials_quick_auth_on">已開啟</string>
+    <string name="profile_settings_campus_credentials_quick_auth_off">已關閉</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enable_action">開啟快速認證</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disable_action">關閉快速認證</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_subtitle">關閉後，平台將停止基於已保存憑證進行快速認證或會話同步。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_subtitle">開啟前需要有效授權和已保存憑證；如條件不滿足，服務端會回傳失敗原因。</string>
+    <string name="profile_settings_campus_credentials_revoke_title">撤回校園帳號憑證授權</string>
+    <string name="profile_settings_campus_credentials_revoke_action">撤回授權</string>
+    <string name="profile_settings_campus_credentials_revoke_confirmation">撤回授權將停止後續基於已保存校園憑證的快速認證或會話同步；如服務端設定為安全優先處理，已保存憑證也可能被同步刪除。</string>
+    <string name="profile_settings_campus_credentials_delete_title">刪除已保存的校園憑證</string>
+    <string name="profile_settings_campus_credentials_delete_action">刪除已保存憑證</string>
+    <string name="profile_settings_campus_credentials_delete_confirmation">刪除後，課表、成績、校園卡、圖書館等查詢可能需要重新登入或重新授權。</string>
+    <string name="profile_settings_campus_credentials_revoke_success">授權已撤回，平台將停止基於已保存憑證進行快速認證或會話同步。</string>
+    <string name="profile_settings_campus_credentials_delete_success">已刪除保存的校園憑證，後續課表、成績、校園卡、圖書館等查詢可能需要重新登入或重新授權。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_success">快速認證已開啟</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_success">快速認證已關閉</string>
+    <string name="profile_settings_campus_credentials_action_failed">校園憑證操作失敗，請稍後再試</string>
     <string name="profile_delete_title">註銷帳號</string>
     <string name="profile_delete_entry_subtitle">提交帳號註銷申請並清理本機登入態</string>
     <string name="profile_delete_warning_title">此操作不可恢復</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <string name="login_mock_enabled_subtitle">当前登录将使用本地示例数据</string>
     <string name="login_mock_disabled_subtitle">关闭后将使用当前服务环境</string>
     <string name="login_mock_account_hint">本地示例登录仅用于界面验证与联调演示</string>
+    <string name="login_campus_credential_consent_label">我已阅读并单独同意平台在必要范围内处理我的校园账号凭证，用于校园身份认证、快速认证、校园数据查询及与学校系统的必要会话同步。</string>
+    <string name="login_campus_credential_consent_note">你可以在设置中查看授权状态、撤回授权、删除已保存凭证或关闭快速认证。</string>
+    <string name="login_campus_credential_consent_required">请先单独同意校园凭证授权后再登录</string>
     <string name="privacy_policy">隐私政策</string>
 
     <!-- 2.0 通用 -->
@@ -1390,6 +1393,36 @@
     <string name="profile_settings_environment_endpoint_title">当前服务地址</string>
     <string name="profile_settings_version_title">当前版本</string>
     <string name="profile_settings_toggle_failed">切换设置失败</string>
+    <string name="profile_settings_campus_credentials_title">校园凭证管理</string>
+    <string name="profile_settings_campus_credentials_subtitle">查看授权状态、已保存凭证和快速认证，并可随时撤回授权或删除已保存凭证。</string>
+    <string name="profile_settings_campus_credentials_loading">正在同步校园凭证状态…</string>
+    <string name="profile_settings_campus_credentials_consent_status_label">授权状态</string>
+    <string name="profile_settings_campus_credentials_saved_label">已保存凭证</string>
+    <string name="profile_settings_campus_credentials_quick_auth_label">快速认证</string>
+    <string name="profile_settings_campus_credentials_account_label">校园账号</string>
+    <string name="profile_settings_campus_credentials_consented_at_label">授权时间</string>
+    <string name="profile_settings_campus_credentials_revoked_at_label">撤回时间</string>
+    <string name="profile_settings_campus_credentials_status_authorized">已授权</string>
+    <string name="profile_settings_campus_credentials_status_unauthorized">未授权</string>
+    <string name="profile_settings_campus_credentials_boolean_yes">是</string>
+    <string name="profile_settings_campus_credentials_boolean_no">否</string>
+    <string name="profile_settings_campus_credentials_quick_auth_on">已开启</string>
+    <string name="profile_settings_campus_credentials_quick_auth_off">已关闭</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enable_action">开启快速认证</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disable_action">关闭快速认证</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_subtitle">关闭后，平台将停止基于已保存凭证进行快速认证或会话同步。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_subtitle">开启前需要有效授权和已保存凭证；如条件不满足，服务端会返回失败原因。</string>
+    <string name="profile_settings_campus_credentials_revoke_title">撤回校园账号凭证授权</string>
+    <string name="profile_settings_campus_credentials_revoke_action">撤回授权</string>
+    <string name="profile_settings_campus_credentials_revoke_confirmation">撤回授权将停止后续基于已保存校园凭证的快速认证或会话同步；如服务端配置为安全优先处理，已保存凭证也可能被同步删除。</string>
+    <string name="profile_settings_campus_credentials_delete_title">删除已保存的校园凭证</string>
+    <string name="profile_settings_campus_credentials_delete_action">删除已保存凭证</string>
+    <string name="profile_settings_campus_credentials_delete_confirmation">删除后，课表、成绩、校园卡、图书馆等查询可能需要重新登录或重新授权。</string>
+    <string name="profile_settings_campus_credentials_revoke_success">授权已撤回，平台将停止基于已保存凭证进行快速认证或会话同步。</string>
+    <string name="profile_settings_campus_credentials_delete_success">已删除保存的校园凭证，后续课表、成绩、校园卡、图书馆等查询可能需要重新登录或重新授权。</string>
+    <string name="profile_settings_campus_credentials_quick_auth_enabled_success">快速认证已开启</string>
+    <string name="profile_settings_campus_credentials_quick_auth_disabled_success">快速认证已关闭</string>
+    <string name="profile_settings_campus_credentials_action_failed">校园凭证操作失败，请稍后重试</string>
     <string name="profile_delete_title">注销账号</string>
     <string name="profile_delete_entry_subtitle">提交账号注销申请并清理本地登录态</string>
     <string name="profile_delete_warning_title">此操作不可恢复</string>

--- a/app/src/test/java/cn/gdeiassistant/data/AuthRepositoryContractTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/AuthRepositoryContractTest.kt
@@ -1,6 +1,8 @@
 package cn.gdeiassistant.data
 
+import cn.gdeiassistant.model.CampusCredentialConsentMetadata
 import cn.gdeiassistant.model.DataJsonResult
+import cn.gdeiassistant.model.LoginRequest
 import cn.gdeiassistant.model.UserLoginResult
 import cn.gdeiassistant.network.AppException
 import cn.gdeiassistant.network.api.AuthApi
@@ -16,6 +18,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -23,9 +26,6 @@ import org.mockito.kotlin.whenever
 /**
  * Contract tests for [AuthRepository]: verifies that the repository correctly maps
  * [AuthApi] responses to [Result] and delegates token persistence to [SessionManager].
- *
- * These tests operate at the repository level using mocked API/session dependencies.
- * They do not require Android context for the tested paths.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AuthRepositoryContractTest {
@@ -103,6 +103,36 @@ class AuthRepositoryContractTest {
 
         authRepository.login("alice", "s3cret")
 
-        verify(authApi).login(mapOf("username" to "alice", "password" to "s3cret"))
+        verify(authApi).login(LoginRequest(username = "alice", password = "s3cret"))
+    }
+
+    @Test
+    fun loginApiCallIncludesConsentMetadataWhenProvided() = runTest(testDispatcher) {
+        whenever(authApi.login(any())).thenReturn(
+            DataJsonResult(success = true, code = 200, data = UserLoginResult(token = "tok"))
+        )
+
+        authRepository.login(
+            username = "alice",
+            password = "s3cret",
+            consentMetadata = CampusCredentialConsentMetadata(
+                scene = "LOGIN",
+                policyDate = "2026-04-25",
+                effectiveDate = "2026-05-11"
+            )
+        )
+
+        verify(authApi).login(
+            eq(
+                LoginRequest(
+                    username = "alice",
+                    password = "s3cret",
+                    campusCredentialConsent = true,
+                    consentScene = "LOGIN",
+                    policyDate = "2026-04-25",
+                    effectiveDate = "2026-05-11"
+                )
+            )
+        )
     }
 }

--- a/app/src/test/java/cn/gdeiassistant/data/CampusCredentialRepositoryContractTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/CampusCredentialRepositoryContractTest.kt
@@ -1,0 +1,120 @@
+package cn.gdeiassistant.data
+
+import cn.gdeiassistant.model.CampusCredentialConsentMetadata
+import cn.gdeiassistant.model.DataJsonResult
+import cn.gdeiassistant.network.api.CampusCredentialApi
+import cn.gdeiassistant.network.api.CampusCredentialQuickAuthRequest
+import cn.gdeiassistant.network.api.CampusCredentialStatusDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CampusCredentialRepositoryContractTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var campusCredentialApi: CampusCredentialApi
+    private lateinit var repository: CampusCredentialRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        campusCredentialApi = mock()
+        repository = CampusCredentialRepository(campusCredentialApi)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun getStatusMapsSafeFieldsAndMasksAccount() = runTest(testDispatcher) {
+        whenever(campusCredentialApi.getStatus()).thenReturn(
+            DataJsonResult(
+                success = true,
+                code = 200,
+                data = CampusCredentialStatusDto(
+                    hasActiveConsent = true,
+                    hasSavedCredential = true,
+                    quickAuthEnabled = true,
+                    consentedAt = "2026-04-26 10:00:00",
+                    maskedCampusAccount = "2023001746"
+                )
+            )
+        )
+
+        val result = repository.getCampusCredentialStatus().getOrThrow()
+
+        assertTrue(result.hasActiveConsent)
+        assertTrue(result.hasSavedCredential)
+        assertTrue(result.quickAuthEnabled)
+        assertEquals("2026-04-26 10:00:00", result.consentedAt)
+        assertEquals("20****46", result.maskedCampusAccount)
+    }
+
+    @Test
+    fun recordConsentDelegatesMetadata() = runTest(testDispatcher) {
+        whenever(campusCredentialApi.recordConsent(any())).thenReturn(
+            DataJsonResult(success = true, code = 200, data = CampusCredentialStatusDto(hasActiveConsent = true))
+        )
+
+        repository.recordCampusCredentialConsent(
+            CampusCredentialConsentMetadata(
+                scene = "LOGIN",
+                policyDate = "2026-04-25",
+                effectiveDate = "2026-05-11"
+            )
+        )
+
+        verify(campusCredentialApi).recordConsent(
+            argThat {
+                scene == "LOGIN" &&
+                    policyDate == "2026-04-25" &&
+                    effectiveDate == "2026-05-11"
+            }
+        )
+    }
+
+    @Test
+    fun revokeAndDeleteDelegateToApi() = runTest(testDispatcher) {
+        whenever(campusCredentialApi.revokeConsent()).thenReturn(
+            DataJsonResult(success = true, code = 200, data = CampusCredentialStatusDto())
+        )
+        whenever(campusCredentialApi.deleteCredential()).thenReturn(
+            DataJsonResult(success = true, code = 200, data = CampusCredentialStatusDto())
+        )
+
+        repository.revokeCampusCredentialConsent()
+        repository.deleteCampusCredential()
+
+        verify(campusCredentialApi).revokeConsent()
+        verify(campusCredentialApi).deleteCredential()
+    }
+
+    @Test
+    fun setQuickAuthEnabledDelegatesFlagAndKeepsFailureMessage() = runTest(testDispatcher) {
+        whenever(campusCredentialApi.updateQuickAuth(any())).thenReturn(
+            DataJsonResult(success = false, code = 400, message = "Missing active consent")
+        )
+
+        val result = repository.setQuickAuthEnabled(true)
+
+        verify(campusCredentialApi).updateQuickAuth(CampusCredentialQuickAuthRequest(enabled = true))
+        assertTrue(result.isFailure)
+        assertEquals("Missing active consent", result.exceptionOrNull()?.message)
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/model/AccountCenterModelsTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/model/AccountCenterModelsTest.kt
@@ -1,0 +1,40 @@
+package cn.gdeiassistant.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AccountCenterModelsTest {
+
+    @Test
+    fun maskPhoneKeepsUsefulPrefixAndSuffix() {
+        assertEquals("138****5678", maskPhone("13812345678"))
+        assertEquals("", maskPhone(null))
+        assertEquals("123", maskPhone("123"))
+    }
+
+    @Test
+    fun maskEmailKeepsDomainButNotRawLocalPart() {
+        assertEquals("abc***@example.com", maskEmail("abcdef@example.com"))
+        assertEquals("", maskEmail(null))
+        assertEquals("plain-text", maskEmail("plain-text"))
+    }
+
+    @Test
+    fun maskAccountHidesMostCharacters() {
+        assertEquals("20****46", maskAccount("2023001746"))
+        assertEquals("a***", maskAccount("ab"))
+        assertEquals("", maskAccount(null))
+    }
+
+    @Test
+    fun maskTokenNeverReturnsRawLongToken() {
+        val raw = "eyJhbGciOiJIUzI1NiJ9.payload.signature"
+        val masked = maskToken(raw)
+        assertTrue(masked != raw)
+        assertTrue(masked.startsWith("eyJh"))
+        assertTrue(masked.endsWith("ture"))
+        assertEquals("", maskToken(null))
+        assertEquals("***", maskToken("abc"))
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/login/LoginViewModelTest.kt
@@ -116,6 +116,22 @@ class LoginViewModelTest {
         verify(authRepository).login(eq("student"), eq("password123"), isNull())
     }
 
+    @Test
+    fun mockModeSwitchBlocksLoginUntilPersisted() = runTest(testDispatcher) {
+        setSyncMockModeEnabled(true)
+        mockModeFlow.value = true
+        val viewModel = LoginViewModel(authRepository, settingsRepository, context)
+        advanceUntilIdle()
+
+        viewModel.updateUsername("student")
+        viewModel.updatePassword("password123")
+        viewModel.setMockModeEnabled(false)
+        viewModel.login()
+
+        verifyNoInteractions(authRepository)
+        assertEquals(false, viewModel.uiState.value.canSubmit)
+    }
+
     private fun setSyncMockModeEnabled(value: Boolean) {
         val field: Field = SettingsRepository::class.java.getDeclaredField("mockModeEnabledCache")
         field.isAccessible = true

--- a/app/src/test/java/cn/gdeiassistant/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/login/LoginViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import java.lang.reflect.Field
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -44,6 +45,7 @@ class LoginViewModelTest {
         settingsRepository = mock()
         context = mock()
         mockModeFlow = MutableStateFlow(false)
+        setSyncMockModeEnabled(false)
 
         whenever(settingsRepository.isMockModeEnabled).thenReturn(mockModeFlow)
         whenever(context.getString(R.string.login_campus_credential_consent_required)).thenReturn("请先完成校园凭证授权")
@@ -53,6 +55,7 @@ class LoginViewModelTest {
 
     @After
     fun tearDown() {
+        setSyncMockModeEnabled(false)
         Dispatchers.resetMain()
     }
 
@@ -100,6 +103,7 @@ class LoginViewModelTest {
 
     @Test
     fun mockModeBypassesCampusCredentialConsentGate() = runTest(testDispatcher) {
+        setSyncMockModeEnabled(true)
         mockModeFlow.value = true
         whenever(authRepository.login(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(Result.success(Unit))
         val viewModel = LoginViewModel(authRepository, settingsRepository, context)
@@ -111,4 +115,11 @@ class LoginViewModelTest {
 
         verify(authRepository).login(eq("student"), eq("password123"), isNull())
     }
+
+    private fun setSyncMockModeEnabled(value: Boolean) {
+        val field: Field = SettingsRepository::class.java.getDeclaredField("mockModeEnabledCache")
+        field.isAccessible = true
+        field.setBoolean(null, value)
+    }
+
 }

--- a/app/src/test/java/cn/gdeiassistant/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/login/LoginViewModelTest.kt
@@ -1,0 +1,114 @@
+package cn.gdeiassistant.ui.login
+
+import android.content.Context
+import cn.gdeiassistant.R
+import cn.gdeiassistant.data.AuthRepository
+import cn.gdeiassistant.data.SettingsRepository
+import cn.gdeiassistant.model.CampusCredentialConsentMetadata
+import cn.gdeiassistant.ui.util.UiText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var authRepository: AuthRepository
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var context: Context
+    private lateinit var mockModeFlow: MutableStateFlow<Boolean>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        authRepository = mock()
+        settingsRepository = mock()
+        context = mock()
+        mockModeFlow = MutableStateFlow(false)
+
+        whenever(settingsRepository.isMockModeEnabled).thenReturn(mockModeFlow)
+        whenever(context.getString(R.string.login_campus_credential_consent_required)).thenReturn("请先完成校园凭证授权")
+        whenever(context.getString(R.string.login_error_empty)).thenReturn("请输入账号和密码")
+        whenever(context.getString(R.string.service_unavailable)).thenReturn("服务暂不可用")
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loginBlocksSubmitWhenConsentIsRequiredButUnchecked() = runTest(testDispatcher) {
+        val viewModel = LoginViewModel(authRepository, settingsRepository, context)
+        viewModel.updateUsername("student")
+        viewModel.updatePassword("password123")
+
+        viewModel.login()
+        advanceUntilIdle()
+
+        verifyNoInteractions(authRepository)
+        assertEquals(
+            UiText.StringResource(R.string.login_campus_credential_consent_required),
+            viewModel.uiState.value.errorMessage
+        )
+    }
+
+    @Test
+    fun loginSendsConsentMetadataWhenChecked() = runTest(testDispatcher) {
+        whenever(authRepository.login(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(Result.success(Unit))
+        val viewModel = LoginViewModel(authRepository, settingsRepository, context)
+        val eventDeferred = async { viewModel.events.first() }
+
+        viewModel.updateUsername("student")
+        viewModel.updatePassword("password123")
+        viewModel.setCampusCredentialConsentChecked(true)
+        viewModel.login()
+        advanceUntilIdle()
+
+        verify(authRepository).login(
+            eq("student"),
+            eq("password123"),
+            eq(
+                CampusCredentialConsentMetadata(
+                    scene = "LOGIN",
+                    policyDate = "2026-04-25",
+                    effectiveDate = "2026-05-11"
+                )
+            )
+        )
+        assertEquals(LoginEvent.NavigateToHome, eventDeferred.await())
+    }
+
+    @Test
+    fun mockModeBypassesCampusCredentialConsentGate() = runTest(testDispatcher) {
+        mockModeFlow.value = true
+        whenever(authRepository.login(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(Result.success(Unit))
+        val viewModel = LoginViewModel(authRepository, settingsRepository, context)
+
+        viewModel.updateUsername("student")
+        viewModel.updatePassword("password123")
+        viewModel.login()
+        advanceUntilIdle()
+
+        verify(authRepository).login(eq("student"), eq("password123"), isNull())
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import java.lang.reflect.Field
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -55,6 +56,8 @@ class ProfileSettingsViewModelTest {
         campusCredentialRepository = mock()
         mockModeFlow = MutableStateFlow(false)
         networkEnvironmentFlow = MutableStateFlow(NetworkEnvironment.STAGING)
+        setSyncMockModeEnabled(false)
+        setSyncNetworkEnvironment(NetworkEnvironment.STAGING)
 
         whenever(settingsRepository.isMockModeEnabled).thenReturn(mockModeFlow)
         whenever(settingsRepository.networkEnvironment).thenReturn(networkEnvironmentFlow)
@@ -83,6 +86,8 @@ class ProfileSettingsViewModelTest {
 
     @After
     fun tearDown() {
+        setSyncMockModeEnabled(false)
+        setSyncNetworkEnvironment(NetworkEnvironment.default())
         Dispatchers.resetMain()
     }
 
@@ -219,5 +224,17 @@ class ProfileSettingsViewModelTest {
 
         assertEquals(ProfileSettingsEvent.ShowMessage("Missing active consent"), eventDeferred.await())
         assertTrue(!viewModel.state.value.isCampusCredentialActionRunning)
+    }
+
+    private fun setSyncMockModeEnabled(value: Boolean) {
+        val field: Field = SettingsRepository::class.java.getDeclaredField("mockModeEnabledCache")
+        field.isAccessible = true
+        field.setBoolean(null, value)
+    }
+
+    private fun setSyncNetworkEnvironment(environment: NetworkEnvironment) {
+        val field: Field = SettingsRepository::class.java.getDeclaredField("networkEnvironmentCache")
+        field.isAccessible = true
+        field.set(null, environment)
     }
 }

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -55,19 +56,21 @@ class ProfileSettingsViewModelTest {
 
         whenever(settingsRepository.isMockModeEnabled).thenReturn(mockModeFlow)
         whenever(settingsRepository.networkEnvironment).thenReturn(networkEnvironmentFlow)
-        whenever(campusCredentialRepository.getCampusCredentialStatus()).thenReturn(Result.success(defaultStatus))
-        whenever(campusCredentialRepository.revokeCampusCredentialConsent()).thenReturn(
-            Result.success(defaultStatus.copy(hasActiveConsent = false, hasSavedCredential = false, quickAuthEnabled = false))
-        )
-        whenever(campusCredentialRepository.deleteCampusCredential()).thenReturn(
-            Result.success(defaultStatus.copy(hasActiveConsent = false, hasSavedCredential = false, quickAuthEnabled = false))
-        )
-        whenever(campusCredentialRepository.setQuickAuthEnabled(true)).thenReturn(
-            Result.failure(IllegalStateException("Missing active consent"))
-        )
-        whenever(campusCredentialRepository.setQuickAuthEnabled(false)).thenReturn(
-            Result.success(defaultStatus.copy(quickAuthEnabled = false))
-        )
+        runBlocking {
+            whenever(campusCredentialRepository.getCampusCredentialStatus()).thenReturn(Result.success(defaultStatus))
+            whenever(campusCredentialRepository.revokeCampusCredentialConsent()).thenReturn(
+                Result.success(defaultStatus.copy(hasActiveConsent = false, hasSavedCredential = false, quickAuthEnabled = false))
+            )
+            whenever(campusCredentialRepository.deleteCampusCredential()).thenReturn(
+                Result.success(defaultStatus.copy(hasActiveConsent = false, hasSavedCredential = false, quickAuthEnabled = false))
+            )
+            whenever(campusCredentialRepository.setQuickAuthEnabled(true)).thenReturn(
+                Result.failure(IllegalStateException("Missing active consent"))
+            )
+            whenever(campusCredentialRepository.setQuickAuthEnabled(false)).thenReturn(
+                Result.success(defaultStatus.copy(quickAuthEnabled = false))
+            )
+        }
         whenever(context.getString(R.string.profile_settings_toggle_failed)).thenReturn("切换失败")
         whenever(context.getString(R.string.profile_settings_campus_credentials_revoke_success)).thenReturn("授权已撤回")
         whenever(context.getString(R.string.profile_settings_campus_credentials_delete_success)).thenReturn("凭证已删除")

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
@@ -24,6 +24,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -105,6 +107,19 @@ class ProfileSettingsViewModelTest {
     }
 
     @Test
+    fun refreshesCampusCredentialStatusWhenBackendTargetFlowsChange() = runTest(testDispatcher) {
+        ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+
+        mockModeFlow.value = true
+        advanceUntilIdle()
+        networkEnvironmentFlow.value = NetworkEnvironment.DEV
+        advanceUntilIdle()
+
+        verify(campusCredentialRepository, times(3)).getCampusCredentialStatus()
+    }
+
+    @Test
     fun setNetworkEnvironmentDelegatesToRepository() = runTest(testDispatcher) {
         val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
 
@@ -112,6 +127,18 @@ class ProfileSettingsViewModelTest {
         advanceUntilIdle()
 
         verify(settingsRepository).setNetworkEnvironment(NetworkEnvironment.PROD)
+    }
+
+    @Test
+    fun backendTargetChangeBlocksCampusCredentialActionsUntilPersisted() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+
+        viewModel.setMockModeEnabled(true)
+        viewModel.revokeCampusCredentialConsent()
+        advanceUntilIdle()
+
+        verify(campusCredentialRepository, never()).revokeCampusCredentialConsent()
     }
 
     @Test

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
@@ -142,6 +142,20 @@ class ProfileSettingsViewModelTest {
     }
 
     @Test
+    fun campusCredentialActionBlocksBackendTargetChangesUntilFinished() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+
+        viewModel.revokeCampusCredentialConsent()
+        viewModel.setMockModeEnabled(true)
+        viewModel.setNetworkEnvironment(NetworkEnvironment.PROD)
+        advanceUntilIdle()
+
+        verify(settingsRepository, never()).setMockModeEnabled(true)
+        verify(settingsRepository, never()).setNetworkEnvironment(NetworkEnvironment.PROD)
+    }
+
+    @Test
     fun setNetworkEnvironmentEmitsReadableFailureMessage() = runTest(testDispatcher) {
         doThrow(IllegalStateException("保存失败")).whenever(settingsRepository).setNetworkEnvironment(NetworkEnvironment.DEV)
         val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/ProfileSettingsViewModelTest.kt
@@ -2,7 +2,9 @@ package cn.gdeiassistant.ui.profile
 
 import android.content.Context
 import cn.gdeiassistant.R
+import cn.gdeiassistant.data.CampusCredentialRepository
 import cn.gdeiassistant.data.SettingsRepository
+import cn.gdeiassistant.model.CampusCredentialStatus
 import cn.gdeiassistant.network.NetworkEnvironment
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -16,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doThrow
@@ -29,20 +32,48 @@ class ProfileSettingsViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var context: Context
     private lateinit var settingsRepository: SettingsRepository
+    private lateinit var campusCredentialRepository: CampusCredentialRepository
     private lateinit var mockModeFlow: MutableStateFlow<Boolean>
     private lateinit var networkEnvironmentFlow: MutableStateFlow<NetworkEnvironment>
+
+    private val defaultStatus = CampusCredentialStatus(
+        hasActiveConsent = true,
+        hasSavedCredential = true,
+        quickAuthEnabled = true,
+        consentedAt = "2026-04-26 10:32:15",
+        maskedCampusAccount = "20****46"
+    )
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         context = mock()
         settingsRepository = mock()
+        campusCredentialRepository = mock()
         mockModeFlow = MutableStateFlow(false)
         networkEnvironmentFlow = MutableStateFlow(NetworkEnvironment.STAGING)
 
         whenever(settingsRepository.isMockModeEnabled).thenReturn(mockModeFlow)
         whenever(settingsRepository.networkEnvironment).thenReturn(networkEnvironmentFlow)
+        whenever(campusCredentialRepository.getCampusCredentialStatus()).thenReturn(Result.success(defaultStatus))
+        whenever(campusCredentialRepository.revokeCampusCredentialConsent()).thenReturn(
+            Result.success(defaultStatus.copy(hasActiveConsent = false, hasSavedCredential = false, quickAuthEnabled = false))
+        )
+        whenever(campusCredentialRepository.deleteCampusCredential()).thenReturn(
+            Result.success(defaultStatus.copy(hasActiveConsent = false, hasSavedCredential = false, quickAuthEnabled = false))
+        )
+        whenever(campusCredentialRepository.setQuickAuthEnabled(true)).thenReturn(
+            Result.failure(IllegalStateException("Missing active consent"))
+        )
+        whenever(campusCredentialRepository.setQuickAuthEnabled(false)).thenReturn(
+            Result.success(defaultStatus.copy(quickAuthEnabled = false))
+        )
         whenever(context.getString(R.string.profile_settings_toggle_failed)).thenReturn("切换失败")
+        whenever(context.getString(R.string.profile_settings_campus_credentials_revoke_success)).thenReturn("授权已撤回")
+        whenever(context.getString(R.string.profile_settings_campus_credentials_delete_success)).thenReturn("凭证已删除")
+        whenever(context.getString(R.string.profile_settings_campus_credentials_quick_auth_enabled_success)).thenReturn("快速认证已开启")
+        whenever(context.getString(R.string.profile_settings_campus_credentials_quick_auth_disabled_success)).thenReturn("快速认证已关闭")
+        whenever(context.getString(R.string.profile_settings_campus_credentials_action_failed)).thenReturn("操作失败")
     }
 
     @After
@@ -51,13 +82,15 @@ class ProfileSettingsViewModelTest {
     }
 
     @Test
-    fun stateTracksMockModeAndNetworkEnvironmentFlows() = runTest(testDispatcher) {
-        val viewModel = ProfileSettingsViewModel(context, settingsRepository)
+    fun stateTracksFlowsAndLoadsCampusCredentialStatus() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
         advanceUntilIdle()
 
         assertEquals(false, viewModel.state.value.isMockModeEnabled)
         assertEquals(NetworkEnvironment.STAGING, viewModel.state.value.networkEnvironment)
         assertEquals(NetworkEnvironment.STAGING.baseUrl, viewModel.state.value.environmentBaseUrl)
+        assertEquals(defaultStatus, viewModel.state.value.campusCredentialStatus)
+        assertEquals(false, viewModel.state.value.isCampusCredentialLoading)
 
         mockModeFlow.value = true
         networkEnvironmentFlow.value = NetworkEnvironment.DEV
@@ -70,7 +103,7 @@ class ProfileSettingsViewModelTest {
 
     @Test
     fun setNetworkEnvironmentDelegatesToRepository() = runTest(testDispatcher) {
-        val viewModel = ProfileSettingsViewModel(context, settingsRepository)
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
 
         viewModel.setNetworkEnvironment(NetworkEnvironment.PROD)
         advanceUntilIdle()
@@ -81,12 +114,66 @@ class ProfileSettingsViewModelTest {
     @Test
     fun setNetworkEnvironmentEmitsReadableFailureMessage() = runTest(testDispatcher) {
         doThrow(IllegalStateException("保存失败")).whenever(settingsRepository).setNetworkEnvironment(NetworkEnvironment.DEV)
-        val viewModel = ProfileSettingsViewModel(context, settingsRepository)
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
         val eventDeferred = async { viewModel.events.first() }
 
         viewModel.setNetworkEnvironment(NetworkEnvironment.DEV)
         advanceUntilIdle()
 
         assertEquals(ProfileSettingsEvent.ShowMessage("保存失败"), eventDeferred.await())
+    }
+
+    @Test
+    fun revokeConsentUpdatesStatusAndShowsMessage() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+        val eventDeferred = async { viewModel.events.first() }
+
+        viewModel.revokeCampusCredentialConsent()
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.state.value.campusCredentialStatus.hasActiveConsent)
+        assertEquals(false, viewModel.state.value.campusCredentialStatus.quickAuthEnabled)
+        assertEquals(ProfileSettingsEvent.ShowMessage("授权已撤回"), eventDeferred.await())
+    }
+
+    @Test
+    fun deleteCredentialUpdatesStatusAndShowsMessage() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+        val eventDeferred = async { viewModel.events.first() }
+
+        viewModel.deleteCampusCredential()
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.state.value.campusCredentialStatus.hasSavedCredential)
+        assertEquals(ProfileSettingsEvent.ShowMessage("凭证已删除"), eventDeferred.await())
+    }
+
+
+    @Test
+    fun quickAuthDisableSuccessUpdatesStatusAndShowsMessage() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+        val eventDeferred = async { viewModel.events.first() }
+
+        viewModel.setQuickAuthEnabled(false)
+        advanceUntilIdle()
+
+        assertEquals(false, viewModel.state.value.campusCredentialStatus.quickAuthEnabled)
+        assertEquals(ProfileSettingsEvent.ShowMessage("快速认证已关闭"), eventDeferred.await())
+    }
+
+    @Test
+    fun quickAuthFailureUsesBackendMessage() = runTest(testDispatcher) {
+        val viewModel = ProfileSettingsViewModel(context, settingsRepository, campusCredentialRepository)
+        advanceUntilIdle()
+        val eventDeferred = async { viewModel.events.first() }
+
+        viewModel.setQuickAuthEnabled(true)
+        advanceUntilIdle()
+
+        assertEquals(ProfileSettingsEvent.ShowMessage("Missing active consent"), eventDeferred.await())
+        assertTrue(!viewModel.state.value.isCampusCredentialActionRunning)
     }
 }


### PR DESCRIPTION
Summary:
- Add Android client support for campus credential status, consent, revocation, deletion, and quick-auth controls.
- Require standalone campus credential consent before campus account/password login.
- Connect settings UI to backend campus credential management APIs.
- Keep sensitive credential values out of UI and logs.
- Add tests for credential consent and management behavior where stable.

Validation:
- ./gradlew testDebugUnitTest: not run locally because the Android SDK location is unavailable on this VPS (`local.properties` points to a missing sdk.dir)
- ./gradlew lintDebug: not run locally because the Android SDK location is unavailable on this VPS (`local.properties` points to a missing sdk.dir)
- ./gradlew assembleDebug: not run locally because the Android SDK location is unavailable on this VPS (`local.properties` points to a missing sdk.dir)
- GitHub Actions: pending

Notes:
- This PR does not change legal subject information, policy dates, public filing information, backend APIs, or broad personal information export/deletion workflows.
- Quick authentication depends on active consent, saved credentials, and backend quick-auth status.
- If local Android SDK is unavailable, GitHub Actions should be treated as the source of truth for Gradle validation.
