### PR TITLE
Remove client-side charge HMAC secret

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/ChargeRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/ChargeRepository.kt
@@ -8,8 +8,6 @@ import cn.gdeiassistant.network.safeApiCall
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -25,17 +23,10 @@ class ChargeRepository @Inject constructor(
 
     suspend fun submitCharge(amount: Int, password: String): Result<Charge> = withContext(Dispatchers.IO) {
         try {
-            val timestamp = System.currentTimeMillis().toString()
-            val payload = "amount=$amount&timestamp=$timestamp"
-            val secret = context.getString(R.string.request_validate_token)
-            val hmac = hmacSha256(secret, payload)
-
             val charge = safeApiCall {
                 chargeApi.submitCharge(
                     amount = amount.toString(),
-                    password = password,
-                    hmac = hmac,
-                    timestamp = timestamp
+                    password = password
                 )
             }.getOrElse { return@withContext Result.failure(it) }
                 ?: return@withContext Result.failure(
@@ -51,12 +42,5 @@ class ChargeRepository @Inject constructor(
         } catch (e: Exception) {
             Result.failure(e)
         }
-    }
-
-    private fun hmacSha256(secret: String, data: String): String {
-        val mac = Mac.getInstance("HmacSHA256")
-        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
-        return mac.doFinal(data.toByteArray(Charsets.UTF_8))
-            .joinToString("") { "%02x".format(it) }
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/network/api/ChargeApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/ChargeApi.kt
@@ -15,8 +15,6 @@ interface ChargeApi {
     @POST("api/card/charge")
     suspend fun submitCharge(
         @Field("amount") amount: String,
-        @Field("password") password: String,
-        @Field("hmac") hmac: String,
-        @Field("timestamp") timestamp: String
+        @Field("password") password: String
     ): DataJsonResult<Charge>
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2,14 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">Campus Assistant</string>
-
-
-    <!-- Request Token -->
-    <string
-        name="request_validate_token"
-        translatable="false"
-        tools:ignore="Typos">7UnEVKNng3XV/eBcsL1/lRIANRfXcoPT</string>
-
     <!-- General -->
     <string name="service_unavailable">Service temporarily unavailable</string>
     <string name="check_upgrade">Check for updates</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2,14 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">キャンパスアシスタント</string>
-
-
-    <!-- 請求トークン -->
-    <string
-        name="request_validate_token"
-        translatable="false"
-        tools:ignore="Typos">7UnEVKNng3XV/eBcsL1/lRIANRfXcoPT</string>
-
     <!-- 汎用メッセージ -->
     <string name="service_unavailable">サービスは一時的に利用できません</string>
     <string name="check_upgrade">ソフトウェアの更新を確認</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2,14 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">캠퍼스 어시스턴트</string>
-
-
-    <!-- 요청 토큰 -->
-    <string
-        name="request_validate_token"
-        translatable="false"
-        tools:ignore="Typos">7UnEVKNng3XV/eBcsL1/lRIANRfXcoPT</string>
-
     <!-- 일반 안내 -->
     <string name="service_unavailable">서비스를 일시적으로 이용할 수 없습니다</string>
     <string name="check_upgrade">소프트웨어 업데이트 확인</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,14 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">廣東二師助手</string>
-
-
-    <!-- 請求令牌 -->
-    <string
-        name="request_validate_token"
-        translatable="false"
-        tools:ignore="Typos">7UnEVKNng3XV/eBcsL1/lRIANRfXcoPT</string>
-
     <!-- 通用提示 -->
     <string name="service_unavailable">服務暫不可用</string>
     <string name="check_upgrade">檢查軟件更新</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,14 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name">廣東二師助手</string>
-
-
-    <!-- 請求令牌 -->
-    <string
-        name="request_validate_token"
-        translatable="false"
-        tools:ignore="Typos">7UnEVKNng3XV/eBcsL1/lRIANRfXcoPT</string>
-
     <!-- 通用提示 -->
     <string name="service_unavailable">服務暫不可用</string>
     <string name="check_upgrade">檢查軟體更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:locale="zh">
 
     <string name="app_name">广东二师助手</string>
-
-
-    <!-- 请求令牌 -->
-    <string
-        name="request_validate_token"
-        translatable="false"
-        tools:ignore="Typos">7UnEVKNng3XV/eBcsL1/lRIANRfXcoPT</string>
-
     <!-- 通用提示 -->
     <string name="service_unavailable">服务暂不可用</string>
     <string name="check_upgrade">检查软件更新</string>

--- a/app/src/test/java/cn/gdeiassistant/network/api/ChargeApiTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/api/ChargeApiTest.kt
@@ -1,0 +1,54 @@
+package cn.gdeiassistant.network.api
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class ChargeApiTest {
+
+    private val server = MockWebServer()
+    private lateinit var api: ChargeApi
+
+    @Before
+    fun setUp() {
+        server.start()
+        api = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ChargeApi::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun submitChargeDoesNotSendLegacyHmacFields() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"code":200,"message":"","data":{"alipayURL":"https://pay.example.invalid/synthetic"}}""")
+        )
+
+        api.submitCharge(
+            amount = "50",
+            password = "synthetic-charge-password"
+        )
+
+        val body = server.takeRequest().body.readUtf8()
+
+        assertTrue(body.contains("amount=50"))
+        assertTrue(body.contains("password=synthetic-charge-password"))
+        assertFalse(body.contains("hmac="))
+        assertFalse(body.contains("timestamp="))
+    }
+}


### PR DESCRIPTION
Summary:
- Remove the embedded charge HMAC shared secret from Android resources.
- Stop generating client-side charge HMAC signatures.
- Stop submitting hmac/timestamp fields for charge requests.
- Keep amount/password submission and existing authenticated/device-bound request flow.
- Update tests for the new charge request shape.

Validation:
- ./gradlew testDebugUnitTest: passed with one-time local JVM args: `./gradlew --no-daemon -Dorg.gradle.jvmargs='-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8' testDebugUnitTest`
- ./gradlew lintDebug: passed with the same one-time local JVM args.
- ./gradlew assembleDebug: passed with the same one-time local JVM args.
- git diff --check: passed
- Repository grep: `request_validate_token`, charge HMAC generation, and hmac/timestamp Retrofit fields are no longer present in main/test sources.
- GitHub Actions: pending

Notes:
- This depends on backend PR #165, which made hmac/timestamp legacy-compatible and no longer trusted as a security boundary.
- This PR does not change campus credential controls, policy dates, legal subject information, or public filing information.
- The old shared secret should be treated as exposed and retired after client migration.
