### PR TITLE
Send idempotency keys for charge requests

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/ChargeRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/ChargeRepository.kt
@@ -3,6 +3,7 @@ package cn.gdeiassistant.data
 import android.content.Context
 import cn.gdeiassistant.R
 import cn.gdeiassistant.model.Charge
+import cn.gdeiassistant.network.IdempotencyKeyGenerator
 import cn.gdeiassistant.network.api.ChargeApi
 import cn.gdeiassistant.network.safeApiCall
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -16,15 +17,18 @@ class ChargeRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val chargeApi: ChargeApi,
     private val cardRepository: CardRepository,
-    private val sessionManager: SessionManager
+    private val sessionManager: SessionManager,
+    private val idempotencyKeyGenerator: IdempotencyKeyGenerator
 ) {
 
     suspend fun getCardInfo() = cardRepository.getCardInfo()
 
     suspend fun submitCharge(amount: Int, password: String): Result<Charge> = withContext(Dispatchers.IO) {
         try {
+            val idempotencyKey = idempotencyKeyGenerator.newKey()
             val charge = safeApiCall {
                 chargeApi.submitCharge(
+                    idempotencyKey = idempotencyKey,
                     amount = amount.toString(),
                     password = password
                 )

--- a/app/src/main/java/cn/gdeiassistant/network/IdempotencyKeyGenerator.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/IdempotencyKeyGenerator.kt
@@ -1,0 +1,11 @@
+package cn.gdeiassistant.network
+
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IdempotencyKeyGenerator @Inject constructor() {
+
+    fun newKey(): String = UUID.randomUUID().toString()
+}

--- a/app/src/main/java/cn/gdeiassistant/network/api/ChargeApi.kt
+++ b/app/src/main/java/cn/gdeiassistant/network/api/ChargeApi.kt
@@ -4,6 +4,7 @@ import cn.gdeiassistant.model.Charge
 import cn.gdeiassistant.model.DataJsonResult
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 /**
@@ -14,6 +15,7 @@ interface ChargeApi {
     @FormUrlEncoded
     @POST("api/card/charge")
     suspend fun submitCharge(
+        @Header("Idempotency-Key") idempotencyKey: String,
         @Field("amount") amount: String,
         @Field("password") password: String
     ): DataJsonResult<Charge>

--- a/app/src/test/java/cn/gdeiassistant/data/ChargeRepositoryContractTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/ChargeRepositoryContractTest.kt
@@ -1,0 +1,107 @@
+package cn.gdeiassistant.data
+
+import android.content.Context
+import cn.gdeiassistant.model.Charge
+import cn.gdeiassistant.model.DataJsonResult
+import cn.gdeiassistant.network.IdempotencyKeyGenerator
+import cn.gdeiassistant.network.api.ChargeApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ChargeRepositoryContractTest {
+
+    private lateinit var context: Context
+    private lateinit var chargeApi: ChargeApi
+    private lateinit var cardRepository: CardRepository
+    private lateinit var sessionManager: SessionManager
+    private lateinit var idempotencyKeyGenerator: IdempotencyKeyGenerator
+    private lateinit var repository: ChargeRepository
+
+    @Before
+    fun setUp() {
+        context = mock()
+        chargeApi = mock()
+        cardRepository = mock()
+        sessionManager = mock()
+        idempotencyKeyGenerator = mock()
+        repository = ChargeRepository(
+            context = context,
+            chargeApi = chargeApi,
+            cardRepository = cardRepository,
+            sessionManager = sessionManager,
+            idempotencyKeyGenerator = idempotencyKeyGenerator
+        )
+    }
+
+    @Test
+    fun submitChargeSendsGeneratedIdempotencyKey() = runTest {
+        whenever(idempotencyKeyGenerator.newKey()).thenReturn("synthetic-idempotency-key")
+        whenever(
+            chargeApi.submitCharge(
+                idempotencyKey = "synthetic-idempotency-key",
+                amount = "50",
+                password = "synthetic-charge-password"
+            )
+        ).thenReturn(successfulCharge())
+
+        val result = repository.submitCharge(50, "synthetic-charge-password")
+
+        assertTrue(result.isSuccess)
+        verify(chargeApi).submitCharge(
+            idempotencyKey = eq("synthetic-idempotency-key"),
+            amount = eq("50"),
+            password = eq("synthetic-charge-password")
+        )
+    }
+
+    @Test
+    fun submitChargeGeneratesNewKeyForNewUserAttempt() = runTest {
+        whenever(idempotencyKeyGenerator.newKey())
+            .thenReturn("synthetic-idempotency-key-1", "synthetic-idempotency-key-2")
+        whenever(
+            chargeApi.submitCharge(
+                idempotencyKey = "synthetic-idempotency-key-1",
+                amount = "50",
+                password = "synthetic-charge-password"
+            )
+        ).thenReturn(successfulCharge())
+        whenever(
+            chargeApi.submitCharge(
+                idempotencyKey = "synthetic-idempotency-key-2",
+                amount = "50",
+                password = "synthetic-charge-password"
+            )
+        ).thenReturn(successfulCharge())
+
+        val first = repository.submitCharge(50, "synthetic-charge-password")
+        val second = repository.submitCharge(50, "synthetic-charge-password")
+
+        assertTrue(first.isSuccess)
+        assertTrue(second.isSuccess)
+        verify(chargeApi).submitCharge(
+            idempotencyKey = eq("synthetic-idempotency-key-1"),
+            amount = eq("50"),
+            password = eq("synthetic-charge-password")
+        )
+        verify(chargeApi).submitCharge(
+            idempotencyKey = eq("synthetic-idempotency-key-2"),
+            amount = eq("50"),
+            password = eq("synthetic-charge-password")
+        )
+    }
+
+    private fun successfulCharge(): DataJsonResult<Charge> {
+        return DataJsonResult(
+            success = true,
+            code = 200,
+            message = "",
+            data = Charge(alipayURL = "https://pay.example.invalid/synthetic-charge")
+        )
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/network/api/ChargeApiTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/network/api/ChargeApiTest.kt
@@ -40,12 +40,15 @@ class ChargeApiTest {
         )
 
         api.submitCharge(
+            idempotencyKey = "synthetic-idempotency-key",
             amount = "50",
             password = "synthetic-charge-password"
         )
 
-        val body = server.takeRequest().body.readUtf8()
+        val request = server.takeRequest()
+        val body = request.body.readUtf8()
 
+        assertTrue(request.getHeader("Idempotency-Key") == "synthetic-idempotency-key")
         assertTrue(body.contains("amount=50"))
         assertTrue(body.contains("password=synthetic-charge-password"))
         assertFalse(body.contains("hmac="))


### PR DESCRIPTION
Summary:
- Generate an Idempotency-Key for Android charge requests.
- Send the key with charge submissions so backend Redis idempotency can collapse duplicate attempts.
- Keep amount/password submission and authenticated/device-bound request flow unchanged.
- Keep hmac/timestamp removed.
- Add tests for the charge request header behavior and new-attempt semantics.

Validation:
- ./gradlew testDebugUnitTest: passed with -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8"
- ./gradlew lintDebug: passed with -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8"
- ./gradlew assembleDebug: passed with -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8"
- Targeted tests: passed for ChargeApiTest and ChargeRepositoryContractTest
- git diff --check: passed

Notes:
- Depends on backend PR #167.
- Does not change campus credential controls, policy dates, legal subject information, or filing information.
- Broader charge order status / UNKNOWN reconciliation remains a backend follow-up.