### PR TITLE
Avoid stale charge order on payment screen

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/charge/ChargeScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/charge/ChargeScreen.kt
@@ -144,7 +144,7 @@ private fun ChargeContent(
     if (state.paymentSession != null) {
         PaymentScreen(
             session = state.paymentSession,
-            order = state.latestOrder,
+            order = state.currentPaymentOrder,
             onBack = {
                 if (paymentCanGoBack) {
                     paymentWebView?.goBack()
@@ -663,7 +663,7 @@ private fun chargeOrderMessage(order: ChargeOrder): String {
         ChargeOrderStatuses.FAILED -> stringResource(R.string.charge_order_status_failed)
         ChargeOrderStatuses.UNKNOWN -> stringResource(R.string.charge_order_status_unknown)
         ChargeOrderStatuses.MANUAL_REVIEW -> stringResource(R.string.charge_order_status_manual_review)
-        else -> order.message?.takeIf { it.isNotBlank() } ?: stringResource(R.string.charge_order_status_fallback)
+        else -> stringResource(R.string.charge_order_status_fallback)
     }
 }
 

--- a/app/src/main/java/cn/gdeiassistant/ui/charge/ChargeViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/charge/ChargeViewModel.kt
@@ -29,6 +29,7 @@ data class ChargeUiState(
     val error: UiText? = null,
     val cardInfo: CardInfo? = null,
     val paymentSession: Charge? = null,
+    val currentPaymentOrder: ChargeOrder? = null,
     val latestOrder: ChargeOrder? = null,
     val recentOrders: List<ChargeOrder> = emptyList(),
     val isLoadingOrders: Boolean = false,
@@ -81,12 +82,11 @@ class ChargeViewModel @Inject constructor(
                         it.copy(isLoading = false, cardInfo = cardInfo, error = null)
                     }
                 },
-                onFailure = { e ->
+                onFailure = {
                     _state.update {
                         it.copy(
                             isLoading = false,
-                            error = e.message?.takeIf(String::isNotBlank)?.let(UiText::DynamicString)
-                                ?: UiText.StringResource(R.string.charge_info_unavailable)
+                            error = UiText.StringResource(R.string.charge_info_unavailable)
                         )
                     }
                 }
@@ -123,7 +123,14 @@ class ChargeViewModel @Inject constructor(
 
             else -> {
                 viewModelScope.launch {
-                    _state.update { it.copy(isSubmitting = true, error = null) }
+                    _state.update {
+                        it.copy(
+                            isSubmitting = true,
+                            error = null,
+                            currentPaymentOrder = null,
+                            orderError = null
+                        )
+                    }
                     repository.submitCharge(amount, password).fold(
                         onSuccess = { charge ->
                             val paymentUrl = charge.alipayURL.orEmpty()
@@ -131,7 +138,7 @@ class ChargeViewModel @Inject constructor(
                                 _state.update {
                                     it.copy(
                                         isSubmitting = false,
-                                        error = UiText.StringResource(R.string.load_failed)
+                                        error = UiText.StringResource(R.string.charge_submit_failed)
                                     )
                                 }
                                 return@fold
@@ -141,6 +148,7 @@ class ChargeViewModel @Inject constructor(
                                 it.copy(
                                     isSubmitting = false,
                                     paymentSession = charge,
+                                    currentPaymentOrder = order,
                                     latestOrder = order ?: it.latestOrder,
                                     recentOrders = order?.let { summary ->
                                         upsertRecentOrder(summary, it.recentOrders)
@@ -155,12 +163,11 @@ class ChargeViewModel @Inject constructor(
                                 )
                             )
                         },
-                        onFailure = { e ->
+                        onFailure = {
                             _state.update {
                                 it.copy(
                                     isSubmitting = false,
-                                    error = e.message?.takeIf(String::isNotBlank)?.let(UiText::DynamicString)
-                                        ?: UiText.StringResource(R.string.load_failed)
+                                    error = UiText.StringResource(R.string.charge_submit_failed)
                                 )
                             }
                         }
@@ -171,7 +178,7 @@ class ChargeViewModel @Inject constructor(
     }
 
     fun clearPaymentPage() {
-        _state.update { it.copy(paymentSession = null) }
+        _state.update { it.copy(paymentSession = null, currentPaymentOrder = null) }
     }
 
     private suspend fun loadRecentOrders() {
@@ -183,16 +190,16 @@ class ChargeViewModel @Inject constructor(
                         isLoadingOrders = false,
                         recentOrders = orders,
                         latestOrder = resolveLatestOrder(it.latestOrder, orders),
+                        currentPaymentOrder = resolveCurrentPaymentOrder(it.currentPaymentOrder, orders),
                         orderError = null
                     )
                 }
             },
-            onFailure = { e ->
+            onFailure = {
                 _state.update {
                     it.copy(
                         isLoadingOrders = false,
-                        orderError = e.message?.takeIf(String::isNotBlank)?.let(UiText::DynamicString)
-                            ?: UiText.StringResource(R.string.charge_order_load_failed)
+                        orderError = UiText.StringResource(R.string.charge_order_load_failed)
                     )
                 }
             }
@@ -224,12 +231,12 @@ class ChargeViewModel @Inject constructor(
     }
 
     private fun resolveLatestOrder(current: ChargeOrder?, orders: List<ChargeOrder>): ChargeOrder? {
-        val currentOrderId = current?.orderId?.takeIf { it.isNotBlank() }
-        return if (currentOrderId == null) {
-            orders.firstOrNull() ?: current
-        } else {
-            orders.firstOrNull { it.orderId == currentOrderId } ?: current
-        }
+        return orders.firstOrNull() ?: current
+    }
+
+    private fun resolveCurrentPaymentOrder(current: ChargeOrder?, orders: List<ChargeOrder>): ChargeOrder? {
+        val currentOrderId = current?.orderId?.takeIf { it.isNotBlank() } ?: return current
+        return orders.firstOrNull { it.orderId == currentOrderId } ?: current
     }
 
     companion object {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -314,6 +314,7 @@
     <string name="charge_agreement">Payment Terms of Service</string>
     <string name="charge_agreement_url">http://ecard.gdei.edu.edu/CardManage/CardInfo/TransferClause</string>
     <string name="charge_processing">Submitting top-up request…</string>
+    <string name="charge_submit_failed">The charge request could not be processed. Try again later.</string>
     <string name="charge_payment_title">Payment</string>
     <string name="charge_payment_badge">Payment pending</string>
     <string name="charge_payment_subtitle">Please complete the Alipay payment. You can return here to confirm status afterwards.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -314,6 +314,7 @@
     <string name="charge_agreement">決済サービス利用規約</string>
     <string name="charge_agreement_url">http://ecard.gdei.edu.edu/CardManage/CardInfo/TransferClause</string>
     <string name="charge_processing">チャージリクエストを送信中…</string>
+    <string name="charge_submit_failed">チャージリクエストを処理できませんでした。後で再試行してください。</string>
     <string name="charge_payment_title">決済画面</string>
     <string name="charge_payment_badge">決済待ち</string>
     <string name="charge_payment_subtitle">Alipay での決済を完了してから、このページに戻って状態を確認できます。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -314,6 +314,7 @@
     <string name="charge_agreement">결제 서비스 약관</string>
     <string name="charge_agreement_url">http://ecard.gdei.edu.edu/CardManage/CardInfo/TransferClause</string>
     <string name="charge_processing">충전 요청 제출 중…</string>
+    <string name="charge_submit_failed">충전 요청을 처리하지 못했습니다. 잠시 후 다시 시도하세요.</string>
     <string name="charge_payment_title">결제 페이지</string>
     <string name="charge_payment_badge">결제 완료 대기</string>
     <string name="charge_payment_subtitle">알리페이 결제를 완료한 후 이 페이지로 돌아와 상태를 확인할 수 있습니다.</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -313,6 +313,7 @@
     <string name="charge_agreement">繳費服務條款</string>
     <string name="charge_agreement_url">http://ecard.gdei.edu.edu/CardManage/CardInfo/TransferClause</string>
     <string name="charge_processing">正在提交充值請求…</string>
+    <string name="charge_submit_failed">充值請求處理失敗，請稍後重試。</string>
     <string name="charge_payment_title">支付頁</string>
     <string name="charge_payment_badge">待完成支付</string>
     <string name="charge_payment_subtitle">請完成支付寶付款，付款完成後可返回此頁確認狀態。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -313,6 +313,7 @@
     <string name="charge_agreement">繳費服務條款</string>
     <string name="charge_agreement_url">http://ecard.gdei.edu.edu/CardManage/CardInfo/TransferClause</string>
     <string name="charge_processing">正在提交儲值請求…</string>
+    <string name="charge_submit_failed">儲值請求處理失敗，請稍後重試。</string>
     <string name="charge_payment_title">付款頁</string>
     <string name="charge_payment_badge">待完成付款</string>
     <string name="charge_payment_subtitle">請完成支付寶付款，付款完成後可返回此頁確認狀態。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,6 +313,7 @@
     <string name="charge_agreement">缴费服务条款</string>
     <string name="charge_agreement_url">http://ecard.gdei.edu.edu/CardManage/CardInfo/TransferClause</string>
     <string name="charge_processing">正在提交充值请求…</string>
+    <string name="charge_submit_failed">充值请求处理失败，请稍后重试。</string>
     <string name="charge_payment_title">支付页</string>
     <string name="charge_payment_badge">待完成支付</string>
     <string name="charge_payment_subtitle">请完成支付宝付款，付款完成后可返回此页确认状态。</string>

--- a/app/src/test/java/cn/gdeiassistant/ui/charge/ChargeViewModelTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/charge/ChargeViewModelTest.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -102,6 +104,8 @@ class ChargeViewModelTest {
         val state = viewModel.state.value
         assertEquals("synthetic-order-id", state.latestOrder?.orderId)
         assertEquals("PAYMENT_SESSION_CREATED", state.latestOrder?.status)
+        assertEquals("synthetic-order-id", state.currentPaymentOrder?.orderId)
+        assertEquals("PAYMENT_SESSION_CREATED", state.currentPaymentOrder?.status)
         assertEquals("synthetic-order-id", state.recentOrders.firstOrNull()?.orderId)
         assertFalse(state.latestOrder?.message.orEmpty().contains("到账成功"))
     }
@@ -126,7 +130,7 @@ class ChargeViewModelTest {
 
         val viewModel = ChargeViewModel(repository, context)
         advanceUntilIdle()
-        assertEquals(UiText.DynamicString("stale order load failure"), viewModel.state.value.orderError)
+        assertEquals(UiText.StringResource(R.string.charge_order_load_failed), viewModel.state.value.orderError)
 
         viewModel.updateAmount("50")
         viewModel.updatePassword("synthetic-charge-password")
@@ -135,6 +139,7 @@ class ChargeViewModelTest {
 
         val state = viewModel.state.value
         assertEquals(null, state.orderError)
+        assertEquals("synthetic-order-id", state.currentPaymentOrder?.orderId)
         assertEquals("synthetic-order-id", state.recentOrders.firstOrNull()?.orderId)
     }
 
@@ -174,24 +179,60 @@ class ChargeViewModelTest {
         viewModel.submitCharge()
         advanceUntilIdle()
         assertEquals("PAYMENT_SESSION_CREATED", viewModel.state.value.latestOrder?.status)
+        assertEquals("PAYMENT_SESSION_CREATED", viewModel.state.value.currentPaymentOrder?.status)
 
         viewModel.refreshChargeOrders()
         advanceUntilIdle()
 
         val state = viewModel.state.value
         assertEquals("PROCESSING", state.latestOrder?.status)
+        assertEquals("PROCESSING", state.currentPaymentOrder?.status)
         assertEquals("PROCESSING", state.recentOrders.firstOrNull()?.status)
     }
 
     @Test
-    fun refreshPrefersFetchedOrderWhenSubmittedSummaryHasNoOrderId() = runTest(testDispatcher) {
+    fun submitChargeWithoutOrderDataDoesNotReuseStaleLatestOrderForPayment() = runTest(testDispatcher) {
+        val staleLatestOrder = ChargeOrder(
+            orderId = "synthetic-stale-order",
+            amount = 20,
+            status = "UNKNOWN",
+            message = "充值状态暂无法确认，请稍后查看订单状态，避免重复提交。"
+        )
+        whenever(repository.getCardInfo()).thenReturn(Result.success(CardInfo(cardBalance = "52.50")))
+        whenever(repository.getRecentChargeOrders(page = 0, size = 5)).thenReturn(Result.success(listOf(staleLatestOrder)))
+        whenever(context.getString(R.string.charge_opening_alipay)).thenReturn("正在启动支付宝，请稍后…")
+        whenever(repository.submitCharge(50, "synthetic-charge-password")).thenReturn(
+            Result.success(
+                Charge(
+                    alipayURL = "https://pay.example.invalid/synthetic-charge"
+                )
+            )
+        )
+
+        val viewModel = ChargeViewModel(repository, context)
+        advanceUntilIdle()
+        assertEquals("synthetic-stale-order", viewModel.state.value.latestOrder?.orderId)
+
+        viewModel.updateAmount("50")
+        viewModel.updatePassword("synthetic-charge-password")
+        viewModel.submitCharge()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("synthetic-stale-order", state.latestOrder?.orderId)
+        assertNull(state.currentPaymentOrder)
+        assertNotNull(state.paymentSession)
+    }
+
+    @Test
+    fun refreshWithDifferentOrderUpdatesLatestWithoutReplacingCurrentPaymentOrder() = runTest(testDispatcher) {
         whenever(repository.getCardInfo()).thenReturn(Result.success(CardInfo(cardBalance = "52.50")))
         whenever(repository.getRecentChargeOrders(page = 0, size = 5)).thenReturn(
             Result.success(emptyList()),
             Result.success(
                 listOf(
                     ChargeOrder(
-                        orderId = "synthetic-order-from-backend",
+                        orderId = "synthetic-different-order",
                         amount = 50,
                         status = "UNKNOWN",
                         message = "充值状态暂无法确认，请稍后查看订单状态，避免重复提交。"
@@ -204,6 +245,7 @@ class ChargeViewModelTest {
             Result.success(
                 Charge(
                     alipayURL = "https://pay.example.invalid/synthetic-charge",
+                    orderId = "synthetic-current-order",
                     status = "PAYMENT_SESSION_CREATED",
                     message = "支付请求已生成，请完成支付并刷新余额。该状态不代表最终到账。"
                 )
@@ -217,13 +259,85 @@ class ChargeViewModelTest {
         viewModel.updatePassword("synthetic-charge-password")
         viewModel.submitCharge()
         advanceUntilIdle()
-        assertEquals(null, viewModel.state.value.latestOrder?.orderId)
+        assertEquals("synthetic-current-order", viewModel.state.value.latestOrder?.orderId)
+        assertEquals("synthetic-current-order", viewModel.state.value.currentPaymentOrder?.orderId)
 
         viewModel.refreshChargeOrders()
         advanceUntilIdle()
 
         val state = viewModel.state.value
-        assertEquals("synthetic-order-from-backend", state.latestOrder?.orderId)
+        assertEquals("synthetic-different-order", state.latestOrder?.orderId)
         assertEquals("UNKNOWN", state.latestOrder?.status)
+        assertEquals("synthetic-current-order", state.currentPaymentOrder?.orderId)
+        assertEquals("PAYMENT_SESSION_CREATED", state.currentPaymentOrder?.status)
+    }
+
+    @Test
+    fun newChargeSubmissionClearsPreviousCurrentPaymentOrderAndOrderError() = runTest(testDispatcher) {
+        whenever(repository.getCardInfo()).thenReturn(Result.success(CardInfo(cardBalance = "52.50")))
+        whenever(repository.getRecentChargeOrders(page = 0, size = 5)).thenReturn(
+            Result.success(emptyList()),
+            Result.failure(IllegalStateException("raw order refresh failure"))
+        )
+        whenever(context.getString(R.string.charge_opening_alipay)).thenReturn("正在启动支付宝，请稍后…")
+        whenever(repository.submitCharge(50, "synthetic-charge-password")).thenReturn(
+            Result.success(
+                Charge(
+                    alipayURL = "https://pay.example.invalid/synthetic-charge",
+                    orderId = "synthetic-first-order",
+                    status = "PAYMENT_SESSION_CREATED",
+                    message = "支付请求已生成，请完成支付并刷新余额。该状态不代表最终到账。"
+                )
+            ),
+            Result.success(
+                Charge(
+                    alipayURL = "https://pay.example.invalid/synthetic-charge-next"
+                )
+            )
+        )
+
+        val viewModel = ChargeViewModel(repository, context)
+        advanceUntilIdle()
+
+        viewModel.updateAmount("50")
+        viewModel.updatePassword("synthetic-charge-password")
+        viewModel.submitCharge()
+        advanceUntilIdle()
+        assertEquals("synthetic-first-order", viewModel.state.value.currentPaymentOrder?.orderId)
+
+        viewModel.refreshChargeOrders()
+        advanceUntilIdle()
+        assertEquals(UiText.StringResource(R.string.charge_order_load_failed), viewModel.state.value.orderError)
+
+        viewModel.submitCharge()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertNull(state.currentPaymentOrder)
+        assertNull(state.orderError)
+        assertEquals("synthetic-first-order", state.latestOrder?.orderId)
+    }
+
+    @Test
+    fun chargeErrorsUseSafeUiMessages() = runTest(testDispatcher) {
+        whenever(repository.getCardInfo()).thenReturn(Result.failure(IllegalStateException("raw card info failure")))
+        whenever(repository.getRecentChargeOrders(page = 0, size = 5)).thenReturn(
+            Result.failure(IllegalStateException("raw order load failure"))
+        )
+        whenever(repository.submitCharge(50, "synthetic-charge-password")).thenReturn(
+            Result.failure(IllegalStateException("raw charge submit failure"))
+        )
+
+        val viewModel = ChargeViewModel(repository, context)
+        advanceUntilIdle()
+        assertEquals(UiText.StringResource(R.string.charge_info_unavailable), viewModel.state.value.error)
+        assertEquals(UiText.StringResource(R.string.charge_order_load_failed), viewModel.state.value.orderError)
+
+        viewModel.updateAmount("50")
+        viewModel.updatePassword("synthetic-charge-password")
+        viewModel.submitCharge()
+        advanceUntilIdle()
+
+        assertEquals(UiText.StringResource(R.string.charge_submit_failed), viewModel.state.value.error)
     }
 }


### PR DESCRIPTION
Summary:
- Ensure the payment screen only shows the order associated with the current payment session.
- Avoid falling back to stale latestOrder when the current charge response has no orderId/status.
- Keep latest order refreshes from replacing the current payment order unless the orderId matches.
- Replace raw exception messages in charge UI state with safe user-facing messages.
- Add tests for stale order prevention and safe error handling.

Validation:
- ./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=384m -Dfile.encoding=UTF-8' testDebugUnitTest --tests cn.gdeiassistant.ui.charge.ChargeViewModelTest: Passed.
- ./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=384m -Dfile.encoding=UTF-8' testDebugUnitTest: Passed.
- ./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=384m -Dfile.encoding=UTF-8' lintDebug: Passed.
- ./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=384m -Dfile.encoding=UTF-8' assembleDebug: Passed.
- git diff --check: Passed.
- GitHub Actions: Pending.

Notes:
- This PR does not change backend APIs, HMAC behavior, campus credential controls, policy dates, legal-subject information, or filing information.
- PAYMENT_SESSION_CREATED still means the payment session was generated, not final balance settlement.
- Local Gradle/VPS memory settings were not committed.