### PR TITLE
Harden release demo controls and language labels

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/data/SettingsRepository.kt
+++ b/app/src/main/java/cn/gdeiassistant/data/SettingsRepository.kt
@@ -19,6 +19,14 @@ import javax.inject.Singleton
 
 private val Context.settingsDataStore by preferencesDataStore(name = "developer_settings")
 
+private fun sanitizeMockModeEnabled(enabled: Boolean): Boolean {
+    return SettingsRepository.canUseDemoMode() && enabled
+}
+
+private fun sanitizeNetworkEnvironment(environment: NetworkEnvironment): NetworkEnvironment {
+    return if (SettingsRepository.canChangeNetworkEnvironment()) environment else NetworkEnvironment.PROD
+}
+
 @Singleton
 class SettingsRepository @Inject constructor(
     @ApplicationContext context: Context
@@ -29,21 +37,27 @@ class SettingsRepository @Inject constructor(
         appContext.getSharedPreferences(SYNC_CACHE_PREFERENCES_NAME, Context.MODE_PRIVATE)
 
     init {
-        mockModeEnabledCache = syncCachePreferences.getBoolean(
-            SYNC_CACHE_KEY_MOCK_MODE_ENABLED,
-            DEFAULT_MOCK_MODE_ENABLED
+        mockModeEnabledCache = sanitizeMockModeEnabled(
+            syncCachePreferences.getBoolean(
+                SYNC_CACHE_KEY_MOCK_MODE_ENABLED,
+                DEFAULT_MOCK_MODE_ENABLED
+            )
         )
-        networkEnvironmentCache = NetworkEnvironment.fromStorage(
-            syncCachePreferences.getString(
-                SYNC_CACHE_KEY_NETWORK_ENVIRONMENT,
-                BuildConfig.DEFAULT_NETWORK_ENVIRONMENT
+        networkEnvironmentCache = sanitizeNetworkEnvironment(
+            NetworkEnvironment.fromStorage(
+                syncCachePreferences.getString(
+                    SYNC_CACHE_KEY_NETWORK_ENVIRONMENT,
+                    BuildConfig.DEFAULT_NETWORK_ENVIRONMENT
+                )
             )
         )
     }
 
     val isMockModeEnabled: Flow<Boolean> =
         appContext.settingsDataStore.data
-            .map { preferences -> preferences[KEY_MOCK_MODE_ENABLED] ?: DEFAULT_MOCK_MODE_ENABLED }
+            .map { preferences ->
+                sanitizeMockModeEnabled(preferences[KEY_MOCK_MODE_ENABLED] ?: DEFAULT_MOCK_MODE_ENABLED)
+            }
             .distinctUntilChanged()
             .onEach { enabled -> persistMockModeCache(enabled) }
 
@@ -55,18 +69,25 @@ class SettingsRepository @Inject constructor(
     val networkEnvironment: Flow<NetworkEnvironment> =
         appContext.settingsDataStore.data
             .map { preferences ->
-                NetworkEnvironment.fromStorage(
-                    preferences[KEY_NETWORK_ENVIRONMENT] ?: BuildConfig.DEFAULT_NETWORK_ENVIRONMENT
+                sanitizeNetworkEnvironment(
+                    NetworkEnvironment.fromStorage(
+                        preferences[KEY_NETWORK_ENVIRONMENT] ?: BuildConfig.DEFAULT_NETWORK_ENVIRONMENT
+                    )
                 )
             }
             .distinctUntilChanged()
             .onEach(::persistNetworkEnvironmentCache)
 
     suspend fun setMockModeEnabled(enabled: Boolean) {
+        val nextEnabled = sanitizeMockModeEnabled(enabled)
         appContext.settingsDataStore.edit { preferences ->
-            preferences[KEY_MOCK_MODE_ENABLED] = enabled
+            if (canUseDemoMode()) {
+                preferences[KEY_MOCK_MODE_ENABLED] = nextEnabled
+            } else {
+                preferences.remove(KEY_MOCK_MODE_ENABLED)
+            }
         }
-        persistMockModeCache(enabled)
+        persistMockModeCache(nextEnabled)
     }
 
     suspend fun setScheduleBackgroundUri(uri: String?) {
@@ -95,15 +116,28 @@ class SettingsRepository @Inject constructor(
     }
 
     suspend fun setNetworkEnvironment(environment: NetworkEnvironment) {
+        val nextEnvironment = sanitizeNetworkEnvironment(environment)
         appContext.settingsDataStore.edit { preferences ->
-            preferences[KEY_NETWORK_ENVIRONMENT] = environment.storageValue
+            if (canChangeNetworkEnvironment()) {
+                preferences[KEY_NETWORK_ENVIRONMENT] = nextEnvironment.storageValue
+            } else {
+                preferences.remove(KEY_NETWORK_ENVIRONMENT)
+            }
         }
-        persistNetworkEnvironmentCache(environment)
+        persistNetworkEnvironmentCache(nextEnvironment)
     }
 
     suspend fun initializeSyncCache() {
-        persistMockModeCache(isMockModeEnabled.first())
-        persistNetworkEnvironmentCache(networkEnvironment.first())
+        if (canUseDemoMode()) {
+            persistMockModeCache(isMockModeEnabled.first())
+        } else {
+            setMockModeEnabled(false)
+        }
+        if (canChangeNetworkEnvironment()) {
+            persistNetworkEnvironmentCache(networkEnvironment.first())
+        } else {
+            setNetworkEnvironment(NetworkEnvironment.PROD)
+        }
     }
 
     companion object {
@@ -122,22 +156,28 @@ class SettingsRepository @Inject constructor(
         @Volatile
         private var networkEnvironmentCache: NetworkEnvironment = NetworkEnvironment.default()
 
-        fun isMockModeEnabledSync(): Boolean = mockModeEnabledCache
+        fun canUseDemoMode(): Boolean = BuildConfig.DEBUG
 
-        fun currentNetworkEnvironmentSync(): NetworkEnvironment = networkEnvironmentCache
+        fun canChangeNetworkEnvironment(): Boolean = BuildConfig.DEBUG
+
+        fun isMockModeEnabledSync(): Boolean = canUseDemoMode() && mockModeEnabledCache
+
+        fun currentNetworkEnvironmentSync(): NetworkEnvironment = sanitizeNetworkEnvironment(networkEnvironmentCache)
     }
 
     private fun persistMockModeCache(enabled: Boolean) {
-        mockModeEnabledCache = enabled
+        val nextEnabled = sanitizeMockModeEnabled(enabled)
+        mockModeEnabledCache = nextEnabled
         syncCachePreferences.edit()
-            .putBoolean(SYNC_CACHE_KEY_MOCK_MODE_ENABLED, enabled)
+            .putBoolean(SYNC_CACHE_KEY_MOCK_MODE_ENABLED, nextEnabled)
             .apply()
     }
 
     private fun persistNetworkEnvironmentCache(environment: NetworkEnvironment) {
-        networkEnvironmentCache = environment
+        val nextEnvironment = sanitizeNetworkEnvironment(environment)
+        networkEnvironmentCache = nextEnvironment
         syncCachePreferences.edit()
-            .putString(SYNC_CACHE_KEY_NETWORK_ENVIRONMENT, environment.storageValue)
+            .putString(SYNC_CACHE_KEY_NETWORK_ENVIRONMENT, nextEnvironment.storageValue)
             .apply()
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/about/AboutScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/about/AboutScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import cn.gdeiassistant.BuildConfig
 import cn.gdeiassistant.R
 import cn.gdeiassistant.model.CheckUpgradeResult
 import cn.gdeiassistant.ui.components.*
@@ -111,12 +110,14 @@ private fun AboutContent(
                 onOpenDownload = onOpenDownload
             )
         }
-        item {
-            DeveloperSettingsCard(
-                isMockModeEnabled = state.isMockModeEnabled,
-                sourceText = sourceText,
-                onMockModeChange = onMockModeChange
-            )
+        if (state.canUseDemoMode) {
+            item {
+                DeveloperSettingsCard(
+                    isMockModeEnabled = state.isMockModeEnabled,
+                    sourceText = sourceText,
+                    onMockModeChange = onMockModeChange
+                )
+            }
         }
         item {
             SupportCard(

--- a/app/src/main/java/cn/gdeiassistant/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/about/AboutViewModel.kt
@@ -25,7 +25,8 @@ import javax.inject.Inject
 data class AboutUiState(
     val currentVersionName: String = "",
     val currentVersionCode: Long = 0L,
-    val isMockModeEnabled: Boolean = true,
+    val isMockModeEnabled: Boolean = false,
+    val canUseDemoMode: Boolean = SettingsRepository.canUseDemoMode(),
     val isCheckingUpdate: Boolean = false,
     val latestVersion: CheckUpgradeResult? = null,
     val updateAvailable: Boolean = false,
@@ -112,6 +113,7 @@ class AboutViewModel @Inject constructor(
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
+        if (!SettingsRepository.canUseDemoMode()) return
         viewModelScope.launch {
             runCatching {
                 settingsRepository.setMockModeEnabled(enabled)

--- a/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
@@ -23,11 +23,13 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import cn.gdeiassistant.R
 import cn.gdeiassistant.ui.theme.AppShapes
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent

--- a/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
@@ -376,7 +376,7 @@ fun AppTopBar(
                 text = title,
                 style = MaterialTheme.typography.titleLarge.copy(
                     fontWeight = FontWeight.ExtraBold,
-                    letterSpacing = (-0.5).sp
+                    letterSpacing = 0.sp
                 )
             )
         },
@@ -391,7 +391,7 @@ fun AppTopBar(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
+                        contentDescription = stringResource(R.string.back),
                         tint = MaterialTheme.colorScheme.onSurface
                     )
                 }

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginScreen.kt
@@ -142,11 +142,13 @@ private fun LoginContent(
                     onLoginClick()
                 }
             )
-            LoginMockCard(
-                enabled = state.isMockModeEnabled,
-                switchEnabled = !state.isLoading && !state.isMockModeUpdating,
-                onToggle = onMockModeChange
-            )
+            if (state.canUseDemoMode) {
+                LoginMockCard(
+                    enabled = state.isMockModeEnabled,
+                    switchEnabled = !state.isLoading && !state.isMockModeUpdating,
+                    onToggle = onMockModeChange
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginUiState.kt
@@ -6,6 +6,7 @@ data class LoginUiState(
     val username: String = "",
     val password: String = "",
     val isMockModeEnabled: Boolean = false,
+    val canUseDemoMode: Boolean = false,
     val isMockModeUpdating: Boolean = false,
     val isCampusCredentialConsentChecked: Boolean = false,
     val isLoading: Boolean = false,

--- a/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/login/LoginViewModel.kt
@@ -29,7 +29,10 @@ class LoginViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
-        LoginUiState(isMockModeEnabled = SettingsRepository.isMockModeEnabledSync())
+        LoginUiState(
+            isMockModeEnabled = SettingsRepository.isMockModeEnabledSync(),
+            canUseDemoMode = SettingsRepository.canUseDemoMode()
+        )
     )
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
@@ -71,6 +74,7 @@ class LoginViewModel @Inject constructor(
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
+        if (!SettingsRepository.canUseDemoMode()) return
         _uiState.update {
             it.copy(
                 isMockModeEnabled = enabled,

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterScreens.kt
@@ -816,23 +816,26 @@ fun ProfileSettingsScreen(navController: NavHostController) {
                     fontWeight = FontWeight.SemiBold
                 )
                 Spacer(modifier = Modifier.height(12.dp))
-                SettingSwitchRow(
-                    title = stringResource(R.string.profile_settings_mock_title),
-                    subtitle = stringResource(R.string.profile_settings_mock_subtitle),
-                    checked = state.isMockModeEnabled,
-                    enabled = !state.isBackendTargetChanging && !state.isCampusCredentialActionRunning,
-                    onCheckedChange = viewModel::setMockModeEnabled
-                )
-                HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
-                SettingEnvironmentRow(
-                    selectedEnvironment = state.networkEnvironment,
-                    baseUrl = state.environmentBaseUrl,
-                    enabled = state.canChangeNetworkEnvironment &&
-                        !state.isBackendTargetChanging &&
-                        !state.isCampusCredentialActionRunning,
-                    onEnvironmentSelected = viewModel::setNetworkEnvironment
-                )
-                HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
+                if (state.canUseDemoMode) {
+                    SettingSwitchRow(
+                        title = stringResource(R.string.profile_settings_mock_title),
+                        subtitle = stringResource(R.string.profile_settings_mock_subtitle),
+                        checked = state.isMockModeEnabled,
+                        enabled = !state.isBackendTargetChanging && !state.isCampusCredentialActionRunning,
+                        onCheckedChange = viewModel::setMockModeEnabled
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
+                }
+                if (state.canChangeNetworkEnvironment) {
+                    SettingEnvironmentRow(
+                        selectedEnvironment = state.networkEnvironment,
+                        baseUrl = state.environmentBaseUrl,
+                        enabled = !state.isBackendTargetChanging &&
+                            !state.isCampusCredentialActionRunning,
+                        onEnvironmentSelected = viewModel::setNetworkEnvironment
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 14.dp))
+                }
                 SettingInfoRow(
                     title = stringResource(R.string.profile_settings_version_title),
                     value = state.appVersion

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AccountCenterViewModels.kt
@@ -607,10 +607,11 @@ class DeleteAccountViewModel @Inject constructor(
 }
 
 data class ProfileSettingsUiState(
-    val isMockModeEnabled: Boolean = true,
+    val isMockModeEnabled: Boolean = false,
+    val canUseDemoMode: Boolean = SettingsRepository.canUseDemoMode(),
     val networkEnvironment: NetworkEnvironment = NetworkEnvironment.default(),
     val environmentBaseUrl: String = NetworkEnvironment.default().baseUrl,
-    val canChangeNetworkEnvironment: Boolean = BuildConfig.DEBUG,
+    val canChangeNetworkEnvironment: Boolean = SettingsRepository.canChangeNetworkEnvironment(),
     val appVersion: String = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
     val campusCredentialStatus: CampusCredentialStatus = CampusCredentialStatus(),
     val isCampusCredentialLoading: Boolean = true,
@@ -677,7 +678,10 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun setMockModeEnabled(enabled: Boolean) {
-        if (_state.value.isBackendTargetChanging || _state.value.isCampusCredentialActionRunning) return
+        if (!SettingsRepository.canUseDemoMode() ||
+            _state.value.isBackendTargetChanging ||
+            _state.value.isCampusCredentialActionRunning
+        ) return
         _state.update {
             it.copy(
                 isMockModeEnabled = enabled,
@@ -707,7 +711,10 @@ class ProfileSettingsViewModel @Inject constructor(
     }
 
     fun setNetworkEnvironment(environment: NetworkEnvironment) {
-        if (_state.value.isBackendTargetChanging || _state.value.isCampusCredentialActionRunning) return
+        if (!SettingsRepository.canChangeNetworkEnvironment() ||
+            _state.value.isBackendTargetChanging ||
+            _state.value.isCampusCredentialActionRunning
+        ) return
         _state.update {
             it.copy(
                 networkEnvironment = environment,

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/AppearanceScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/AppearanceScreen.kt
@@ -103,32 +103,23 @@ private fun FontScaleSection(step: Int, onSelect: (Int) -> Unit) {
 
 @Composable
 private fun LanguageSection(selected: String, onSelect: (String) -> Unit) {
-    val locales = listOf(
-        "zh-CN" to "\u7B80\u4F53\u4E2D\u6587",
-        "zh-HK" to "\u7E41\u9AD4\u4E2D\u6587\uFF08\u9999\u6E2F\uFF09",
-        "zh-TW" to "\u7E41\u9AD4\u4E2D\u6587\uFF08\u53F0\u7063\uFF09",
-        "en" to "English",
-        "ja" to "\u65E5\u672C\u8A9E",
-        "ko" to "\uD55C\uAD6D\uC5B4",
-    )
-
     AppearanceSectionCard(title = stringResource(R.string.appearance_language_label)) {
         Column(Modifier.selectableGroup()) {
-            locales.forEach { (code, label) ->
+            supportedLanguageOptions.forEach { option ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .selectable(
-                            selected = selected == code,
-                            onClick = { onSelect(code) },
+                            selected = selected == option.code,
+                            onClick = { onSelect(option.code) },
                             role = Role.RadioButton
                         )
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    RadioButton(selected = selected == code, onClick = null)
+                    RadioButton(selected = selected == option.code, onClick = null)
                     Spacer(Modifier.width(12.dp))
-                    Text(label, style = MaterialTheme.typography.bodyLarge)
+                    Text(option.nativeName, style = MaterialTheme.typography.bodyLarge)
                 }
             }
         }

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/LanguagePickerScreen.kt
@@ -31,20 +31,6 @@ import cn.gdeiassistant.R
 import cn.gdeiassistant.ui.components.LazyScreen
 import kotlinx.coroutines.launch
 
-private data class LanguageOption(
-    val code: String,
-    val nativeName: String
-)
-
-private val languageOptions = listOf(
-    LanguageOption("zh-CN", "简体中文"),
-    LanguageOption("zh-HK", "繁體中文（香港）"),
-    LanguageOption("zh-TW", "繁體中文（台灣）"),
-    LanguageOption("en", "English"),
-    LanguageOption("ja", "日本語"),
-    LanguageOption("ko", "한국어")
-)
-
 @Composable
 fun LanguagePickerScreen(navController: NavHostController) {
     val viewModel: ProfileThemeViewModel = hiltViewModel()
@@ -55,7 +41,7 @@ fun LanguagePickerScreen(navController: NavHostController) {
         title = stringResource(R.string.language_picker_title),
         onBack = navController::popBackStack
     ) {
-        languageOptions.forEach { option ->
+        supportedLanguageOptions.forEach { option ->
             item {
                 LanguageRow(
                     option = option,
@@ -73,7 +59,7 @@ fun LanguagePickerScreen(navController: NavHostController) {
 
 @Composable
 private fun LanguageRow(
-    option: LanguageOption,
+    option: SupportedLanguageOption,
     selected: Boolean,
     onClick: () -> Unit
 ) {

--- a/app/src/main/java/cn/gdeiassistant/ui/profile/SupportedLanguageOptions.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/profile/SupportedLanguageOptions.kt
@@ -1,0 +1,15 @@
+package cn.gdeiassistant.ui.profile
+
+data class SupportedLanguageOption(
+    val code: String,
+    val nativeName: String
+)
+
+val supportedLanguageOptions = listOf(
+    SupportedLanguageOption("zh-CN", "简体中文"),
+    SupportedLanguageOption("zh-HK", "繁體中文（港澳）"),
+    SupportedLanguageOption("zh-TW", "繁體中文（台灣）"),
+    SupportedLanguageOption("en", "English"),
+    SupportedLanguageOption("ja", "日本語"),
+    SupportedLanguageOption("ko", "한국어")
+)

--- a/app/src/main/java/cn/gdeiassistant/ui/theme/Type.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/theme/Type.kt
@@ -16,7 +16,7 @@ val AppTypography = Typography(
         fontWeight = FontWeight.ExtraBold,
         fontSize = 48.sp,
         lineHeight = 56.sp,
-        letterSpacing = (-1).sp
+        letterSpacing = 0.sp
     ),
     headlineLarge = TextStyle(
         fontFamily = FontFamily.SansSerif,

--- a/app/src/test/java/cn/gdeiassistant/data/SettingsRepositoryBuildTypeGuardTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/data/SettingsRepositoryBuildTypeGuardTest.kt
@@ -1,0 +1,47 @@
+package cn.gdeiassistant.data
+
+import cn.gdeiassistant.BuildConfig
+import cn.gdeiassistant.network.NetworkEnvironment
+import java.lang.reflect.Field
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SettingsRepositoryBuildTypeGuardTest {
+
+    @After
+    fun tearDown() {
+        setSyncMockModeEnabled(false)
+        setSyncNetworkEnvironment(NetworkEnvironment.default())
+    }
+
+    @Test
+    fun runtimeDebugOptionsFollowBuildType() {
+        assertEquals(BuildConfig.DEBUG, SettingsRepository.canUseDemoMode())
+        assertEquals(BuildConfig.DEBUG, SettingsRepository.canChangeNetworkEnvironment())
+    }
+
+    @Test
+    fun syncAccessorsAreSanitizedByBuildType() {
+        setSyncMockModeEnabled(true)
+        setSyncNetworkEnvironment(NetworkEnvironment.STAGING)
+
+        assertEquals(BuildConfig.DEBUG, SettingsRepository.isMockModeEnabledSync())
+        assertEquals(
+            if (BuildConfig.DEBUG) NetworkEnvironment.STAGING else NetworkEnvironment.PROD,
+            SettingsRepository.currentNetworkEnvironmentSync()
+        )
+    }
+
+    private fun setSyncMockModeEnabled(value: Boolean) {
+        val field: Field = SettingsRepository::class.java.getDeclaredField("mockModeEnabledCache")
+        field.isAccessible = true
+        field.setBoolean(null, value)
+    }
+
+    private fun setSyncNetworkEnvironment(environment: NetworkEnvironment) {
+        val field: Field = SettingsRepository::class.java.getDeclaredField("networkEnvironmentCache")
+        field.isAccessible = true
+        field.set(null, environment)
+    }
+}

--- a/app/src/test/java/cn/gdeiassistant/ui/profile/SupportedLanguageOptionsTest.kt
+++ b/app/src/test/java/cn/gdeiassistant/ui/profile/SupportedLanguageOptionsTest.kt
@@ -1,0 +1,25 @@
+package cn.gdeiassistant.ui.profile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class SupportedLanguageOptionsTest {
+
+    @Test
+    fun traditionalChineseOptionsUseHongKongMacauAndTaiwanLabels() {
+        val labelsByCode = supportedLanguageOptions.associate { it.code to it.nativeName }
+
+        assertEquals("繁體中文（港澳）", labelsByCode["zh-HK"])
+        assertEquals("繁體中文（台灣）", labelsByCode["zh-TW"])
+        assertFalse(supportedLanguageOptions.any { it.nativeName == "繁體中文（香港）" })
+    }
+
+    @Test
+    fun supportedLanguageOptionsKeepExpectedLocaleOrder() {
+        assertEquals(
+            listOf("zh-CN", "zh-HK", "zh-TW", "en", "ja", "ko"),
+            supportedLanguageOptions.map { it.code }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- force release builds away from mock/demo data and non-prod environments
- hide demo/network controls when runtime debug options are unavailable
- localize the top bar back action and remove negative letter spacing
- share language option labels and rename zh-HK to Hong Kong/Macau

## Verification
- git diff --check
- static search for negative letter spacing and hard-coded Back content description

Note: Android unit tests could not run here because ANDROID_HOME / Android SDK is not configured.