### PR TITLE
Tone down Android app surface chrome

### DIFF
--- a/app/src/main/java/cn/gdeiassistant/ui/components/AppChrome.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/components/AppChrome.kt
@@ -44,7 +44,7 @@ fun Atmosphere(
 fun SectionCard(
     modifier: Modifier = Modifier,
     containerColor: Color = MaterialTheme.colorScheme.surface,
-    borderColor: Color = Color.Unspecified, // Compatibility
+    borderColor: Color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f),
     content: @Composable ColumnScope.() -> Unit
 ) {
     Card(
@@ -53,7 +53,8 @@ fun SectionCard(
         colors = CardDefaults.cardColors(
             containerColor = containerColor
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        border = BorderStroke(1.dp, borderColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Column(
             modifier = Modifier
@@ -75,7 +76,7 @@ fun HeroCard(
         modifier = modifier,
         shape = AppShapes.container, // Larger corners for Hero
         colors = CardDefaults.cardColors(containerColor = Color.Transparent),
-        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/components/CommonComponents.kt
@@ -42,14 +42,16 @@ fun BentoCard(
     contentPadding: PaddingValues = PaddingValues(20.dp),
     content: @Composable ColumnScope.() -> Unit
 ) {
+    val borderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.42f)
     val cardModifier = modifier
         .shadow(
-            elevation = 12.dp,
+            elevation = if (onClick != null) 3.dp else 0.dp,
             shape = AppShapes.card,
-            spotColor = Color.Black.copy(alpha = 0.1f),
-            ambientColor = Color.Black.copy(alpha = 0.05f)
+            spotColor = Color.Black.copy(alpha = 0.08f),
+            ambientColor = Color.Black.copy(alpha = 0.03f)
         )
         .clip(AppShapes.card)
+        .border(1.dp, borderColor, AppShapes.card)
         .background(containerColor)
         .then(
             if (onClick != null)

--- a/app/src/main/java/cn/gdeiassistant/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/screen/HomeScreen.kt
@@ -460,8 +460,11 @@ private fun FeatureGridItem(
         }
         Text(
             text = stringResource(feature.titleRes),
-            style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
-            maxLines = 1,
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontSize = 11.sp,
+                lineHeight = 14.sp
+            ),
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Center
         )


### PR DESCRIPTION
## Summary\n- make SectionCard render as low-chrome bordered surfaces instead of elevated cards\n- reduce BentoCard and hero elevation while preserving interactive affordance\n- allow home feature labels to wrap to two lines for longer localized names\n\n## Verification\n- ./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs=-Xmx768m app:testDebugUnitTest