### PR TITLE
[codex] Add Android emulator smoke CI coverage

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -61,3 +61,61 @@ jobs:
             app/build/reports/lint-results*
             app/build/outputs/apk/debug/
           retention-days: 7
+
+  instrumented-smoke:
+    name: Emulator Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: gradle-android-emulator-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: |
+            gradle-android-emulator-${{ runner.os }}-
+            gradle-android-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Compose smoke tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: ./gradlew connectedDebugAndroidTest --no-daemon --stacktrace
+
+      - name: Upload instrumentation reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-instrumentation-reports
+          path: |
+            app/build/reports/androidTests/
+            app/build/outputs/androidTest-results/
+            app/build/outputs/apk/
+          retention-days: 7

--- a/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
+++ b/app/src/androidTest/java/cn/gdeiassistant/ui/MockUiSmokeTest.kt
@@ -90,9 +90,9 @@ class MockMessagesUiSmokeTest : BaseMockUiSmokeTest(
 
     @Test
     fun mockMessagesRouteShowsAnnouncementsAndInteractions() {
-        waitForText("Message Hub")
-        composeRule.onNodeWithText("Message Hub").assertIsDisplayed()
-        composeRule.onNodeWithText("News, system notices and interaction messages — all in one place.").assertIsDisplayed()
+        waitForText("消息中枢")
+        composeRule.onNodeWithText("消息中枢").assertIsDisplayed()
+        composeRule.onNodeWithText("把新闻、系统公告和互动消息整理到一个统一入口。").assertIsDisplayed()
     }
 }
 
@@ -103,10 +103,10 @@ class MockMarketplaceUiSmokeTest : BaseMockUiSmokeTest(
 
     @Test
     fun mockMarketplaceRouteShowsListAndDetail() {
-        waitForText("Marketplace")
-        composeRule.onNodeWithText("Marketplace").assertIsDisplayed()
-        composeRule.onNodeWithText("My Items").assertIsDisplayed()
-        composeRule.onNodeWithText("List Item").assertIsDisplayed()
+        waitForText("二手交易")
+        composeRule.onNodeWithText("二手交易").assertIsDisplayed()
+        composeRule.onNodeWithText("个人中心").assertIsDisplayed()
+        composeRule.onNodeWithText("发布商品").assertIsDisplayed()
     }
 }
 
@@ -117,9 +117,9 @@ class MockGradeUiSmokeTest : BaseMockUiSmokeTest(
 
     @Test
     fun mockGradeRouteShowsAcademicContent() {
-        waitForText("Grades")
-        composeRule.onNodeWithText("Grades").assertIsDisplayed()
-        composeRule.onNodeWithText("Academic Year").assertIsDisplayed()
-        composeRule.onNodeWithText("5 courses recorded for this academic year").assertIsDisplayed()
+        waitForText("成绩查询")
+        composeRule.onNodeWithText("成绩查询").assertIsDisplayed()
+        composeRule.onNodeWithText("学年").assertIsDisplayed()
+        composeRule.onNodeWithText("当前学年共收录 5 门课程").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
+++ b/app/src/main/java/cn/gdeiassistant/ui/MainActivity.kt
@@ -1,6 +1,10 @@
 package cn.gdeiassistant.ui
 
+import android.content.Context
+import android.content.res.Configuration
 import android.os.Bundle
+import android.os.LocaleList as AndroidLocaleList
+import android.view.ContextThemeWrapper
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -8,6 +12,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.core.os.LocaleListCompat
@@ -16,6 +21,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import cn.gdeiassistant.BuildConfig
+import cn.gdeiassistant.R
 import cn.gdeiassistant.data.SessionManager
 import cn.gdeiassistant.data.SettingsRepository
 import cn.gdeiassistant.data.UserPreferencesRepository
@@ -25,6 +31,7 @@ import cn.gdeiassistant.ui.theme.GdeiAssistantTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.Locale
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -86,13 +93,21 @@ class MainActivity : ComponentActivity() {
                 username = uiTestSeedUsername.ifBlank { "gdeiassistant" }
             )
         }
+        val initialContentLocale = if (uiTestLocale.isNotEmpty()) {
+            AppLocaleSupport.normalizeLocale(uiTestLocale)
+        } else {
+            AppLocaleSupport.currentLocale()
+        }
+        AppLocaleSupport.setCurrentLocale(initialContentLocale)
+        Locale.setDefault(AppLocaleSupport.localeObject(initialContentLocale))
+
         if (uiTestUseMock || uiTestLocale.isNotEmpty()) {
             runBlocking {
                 if (uiTestUseMock) {
                     settingsRepository.setMockModeEnabled(true)
                 }
                 if (uiTestLocale.isNotEmpty()) {
-                    settingsRepository.setLocale(uiTestLocale)
+                    settingsRepository.setLocale(initialContentLocale)
                 }
             }
         }
@@ -116,11 +131,18 @@ class MainActivity : ComponentActivity() {
                 .collectAsStateWithLifecycle(initialValue = UserPreferencesRepository.THEME_SYSTEM)
             val fontScale by userPreferencesRepository.fontScale
                 .collectAsStateWithLifecycle(initialValue = 1.0f)
+            val locale by settingsRepository.locale
+                .collectAsStateWithLifecycle(initialValue = initialContentLocale)
+            val baseDensity = LocalDensity.current
+            val localizedContext = remember(locale) {
+                localizedContext(locale)
+            }
 
             CompositionLocalProvider(
+                LocalContext provides localizedContext,
                 LocalDensity provides Density(
-                    density = LocalDensity.current.density,
-                    fontScale = LocalDensity.current.fontScale * fontScale
+                    density = baseDensity.density,
+                    fontScale = baseDensity.fontScale * fontScale
                 )
             ) {
                 GdeiAssistantTheme(themeMode = themeMode) {
@@ -130,6 +152,17 @@ class MainActivity : ComponentActivity() {
                     )
                 }
             }
+        }
+    }
+
+    private fun localizedContext(locale: String): Context {
+        val normalizedLocale = AppLocaleSupport.normalizeLocale(locale)
+        val configuration = Configuration(resources.configuration)
+        val localeObject = AppLocaleSupport.localeObject(normalizedLocale)
+        configuration.setLocale(localeObject)
+        configuration.setLocales(AndroidLocaleList(localeObject))
+        return ContextThemeWrapper(this, R.style.AppTheme).apply {
+            applyOverrideConfiguration(configuration)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add a dedicated `instrumented-smoke` GitHub Actions job.
- Run `connectedDebugAndroidTest` on API 35 Google APIs x86_64 emulator via `reactivecircus/android-emulator-runner@v2`.
- Make debug UI test locale deterministic for Compose `stringResource` by applying a localized Activity-based `ContextThemeWrapper`.
- Update smoke assertions to validate zh-CN core UI text for Messages, Marketplace, and Grades.
- Upload instrumentation reports, androidTest results, and APKs on failure.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-ci.yml"); puts "android workflow yaml ok"'`
- `actionlint .github/workflows/android-ci.yml` — no findings
- `./gradlew :app:testDebugUnitTest :app:assembleDebug :app:assembleDebugAndroidTest --no-daemon --stacktrace` — passed
- `./gradlew :app:connectedDebugAndroidTest --no-daemon --stacktrace` — API 35 local emulator, 4/4 instrumentation tests passed
- `git diff --check`

Logs:

- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/android/workflow-yaml.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/android/actionlint.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/android/unit-assemble-debug-after-locale-context-final.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/android/connected-debug-android-test-after-locale-context-final.log`
- `/Users/lisiyi/Projects/GdeiAssistantReview/artifacts/landing/git-diff-check.log`

## Notes / Risks

- First remote run may require timeout/cache tuning depending on GitHub-hosted runner emulator startup time.
- The job is intentionally separated from the existing build/test job to keep failures easier to diagnose.
- The locale wrapper must stay Activity-based; replacing `LocalContext` with a plain `createConfigurationContext` result breaks Hilt ViewModel activity lookup.

## Codex review request

Please run/consider Codex review for UI/layout/architecture regressions before merge. This PR was prepared from the multi-repo UI architecture review and is intentionally limited to low-risk scope.
