### PR TITLE
[codex] Suppress accepted launcher icon lint warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,7 +164,13 @@ android {
     }
 
     lint {
-        disable += setOf("GradleDependency", "NewerVersionAvailable", "OldTargetApi")
+        disable += setOf(
+            "GradleDependency",
+            "IconDuplicates",
+            "IconLauncherShape",
+            "NewerVersionAvailable",
+            "OldTargetApi"
+        )
     }
 
 }


### PR DESCRIPTION
## Summary
- Suppress the accepted launcher icon lint checks for the current Android app icon assets.
- Keep the existing launcher artwork unchanged; changing icon shape or round variants is a branding/design decision, not a code cleanup.

## Validation
- `ANDROID_HOME=/Users/lisiyi/Library/Android/sdk ANDROID_SDK_ROOT=/Users/lisiyi/Library/Android/sdk ./gradlew lintDebug --no-daemon`
- `ANDROID_HOME=/Users/lisiyi/Library/Android/sdk ANDROID_SDK_ROOT=/Users/lisiyi/Library/Android/sdk ./gradlew :app:compileDebugKotlin :app:compileDebugJavaWithJavac --no-daemon`
- `git diff --check`

## Lint result
- Before: `0 errors, 183 warnings`
- After: `0 errors, 168 warnings`
- Remaining warning groups: `UnusedResources` (149), `PluralsCandidate` (19)
