### PR TITLE
fix: add network security config and ProGuard rules for release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -68,3 +68,7 @@
 
 # 保留注解信息（Retrofit / Gson / Compose 等依赖）
 -keepattributes *Annotation*
+
+# Keep Gson model and API DTO classes
+-keep class cn.gdeiassistant.model.** { *; }
+-keep class cn.gdeiassistant.network.api.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:fullBackupContent="@xml/full_backup_content"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Development: allow cleartext only for emulator localhost -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+    <!-- Production and staging: HTTPS only -->
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Summary
- Add `network_security_config.xml` — cleartext traffic allowed only for emulator `10.0.2.2` and `localhost`
- Add ProGuard keep rules for Gson model and API DTO classes to prevent serialization failures in release builds

## Test plan
- [x] Builds for debug variant
- [x] ProGuard rules verified